### PR TITLE
After conversion automatically update the file in configured media server

### DIFF
--- a/Muxarr.Core/Api/IMediaServerClient.cs
+++ b/Muxarr.Core/Api/IMediaServerClient.cs
@@ -1,0 +1,17 @@
+using Muxarr.Core.Config;
+
+namespace Muxarr.Core.Api;
+
+public interface IMediaServerClient
+{
+    Task<bool> CanConnect(IApiCredentials config);
+    Task<MediaServerUpdateResult> UpdateMedia(IApiCredentials config, string mediaPath);
+}
+
+public sealed record MediaServerUpdateResult(bool Success, string Mode)
+{
+    public static MediaServerUpdateResult Failed { get; } = new(false, "failed");
+    public static MediaServerUpdateResult ItemRefresh { get; } = new(true, "item refresh request");
+    public static MediaServerUpdateResult PathUpdate { get; } = new(true, "path update request");
+    public static MediaServerUpdateResult LibraryScan { get; } = new(true, "library scan request");
+}

--- a/Muxarr.Core/Api/JellyfinEmbyApiClient.cs
+++ b/Muxarr.Core/Api/JellyfinEmbyApiClient.cs
@@ -1,0 +1,333 @@
+using System.Reflection;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+using Muxarr.Core.Config;
+
+namespace Muxarr.Core.Api;
+
+public class JellyfinEmbyApiClient : IMediaServerClient
+{
+    private readonly ILogger<JellyfinEmbyApiClient> _logger;
+    private readonly IHttpClientFactory _httpClientFactory;
+
+    public const string HttpClientName = "JellyfinEmby";
+
+    private const string SystemInfoUrl = "/System/Info";
+    private const string VirtualFoldersUrl = "/Library/VirtualFolders";
+    private const string ItemsUrl = "/Items";
+    private const string UpdatedMediaUrl = "/Library/Media/Updated";
+    private const int ItemPageSize = 1000;
+    private static readonly string ClientVersion = GetClientVersion();
+    private static readonly StringComparison PathComparison =
+        OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+    public JellyfinEmbyApiClient(ILogger<JellyfinEmbyApiClient> logger, IHttpClientFactory httpClientFactory)
+    {
+        _logger = logger;
+        _httpClientFactory = httpClientFactory;
+    }
+
+    public Task<bool> CanConnect(IApiCredentials config)
+    {
+        return Send(config, HttpMethod.Get, SystemInfoUrl);
+    }
+
+    public async Task<MediaServerUpdateResult> UpdateMedia(IApiCredentials config, string mediaPath)
+    {
+        if (string.IsNullOrWhiteSpace(config.Url) || string.IsNullOrWhiteSpace(config.ApiKey))
+        {
+            _logger.LogWarning("No valid media server url/apikey was found.");
+            return MediaServerUpdateResult.Failed;
+        }
+
+        var normalizedMediaPath = NormalizePath(mediaPath);
+
+        try
+        {
+            using var client = _httpClientFactory.CreateClient(HttpClientName);
+
+            var libraries = await GetLibraries(client, config);
+            foreach (var library in libraries
+                         .Where(l => MatchesLibrary(l, normalizedMediaPath))
+                         .OrderByDescending(l => l.LongestLocationLength))
+            {
+                var item = await FindItemByPath(client, config, library, normalizedMediaPath);
+                if (item?.Id != null && await RefreshItem(client, config, item.Id))
+                {
+                    return MediaServerUpdateResult.ItemRefresh;
+                }
+            }
+
+            if (await SendUpdatedMedia(client, config, normalizedMediaPath))
+            {
+                return MediaServerUpdateResult.PathUpdate;
+            }
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or InvalidOperationException)
+        {
+            _logger.LogError(ex, "Failed to update media server for {Path}", mediaPath);
+        }
+
+        return MediaServerUpdateResult.Failed;
+    }
+
+    private async Task<bool> Send(IApiCredentials config, HttpMethod method, string relativeUrl)
+    {
+        if (string.IsNullOrWhiteSpace(config.Url) || string.IsNullOrWhiteSpace(config.ApiKey))
+        {
+            _logger.LogWarning("No valid media server url/apikey was found.");
+            return false;
+        }
+
+        try
+        {
+            using var client = _httpClientFactory.CreateClient(HttpClientName);
+            using var request = CreateRequest(config, method, relativeUrl);
+            using var response = await client.SendAsync(request);
+            if (!response.IsSuccessStatusCode)
+            {
+                var responseBody = await response.Content.ReadAsStringAsync();
+                _logger.LogWarning("{Method} {Url} returned {StatusCode}: {Body}",
+                    method, request.RequestUri, response.StatusCode, responseBody);
+                return false;
+            }
+
+            return true;
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "HTTP error sending {Method} to {Url}", method, relativeUrl);
+            return false;
+        }
+        catch (TaskCanceledException ex)
+        {
+            _logger.LogWarning(ex, "Request to {Url} timed out", relativeUrl);
+            return false;
+        }
+    }
+
+    private async Task<List<JellyfinEmbyLibrary>> GetLibraries(HttpClient client, IApiCredentials config)
+    {
+        using var request = CreateRequest(config, HttpMethod.Get, VirtualFoldersUrl);
+        using var response = await client.SendAsync(request);
+        if (!response.IsSuccessStatusCode)
+        {
+            var responseBody = await response.Content.ReadAsStringAsync();
+            _logger.LogWarning("GET {Url} returned {StatusCode}: {Body}",
+                request.RequestUri, response.StatusCode, responseBody);
+            return [];
+        }
+
+        var libraries = await response.Content.ReadFromJsonAsync<List<JellyfinEmbyLibrary>>();
+        return libraries ?? [];
+    }
+
+    private async Task<JellyfinEmbyItem?> FindItemByPath(HttpClient client, IApiCredentials config,
+        JellyfinEmbyLibrary library, string normalizedMediaPath)
+    {
+        if (string.IsNullOrWhiteSpace(library.ItemId))
+        {
+            return null;
+        }
+
+        for (var startIndex = 0;; startIndex += ItemPageSize)
+        {
+            using var request = CreateRequest(config, HttpMethod.Get, BuildItemsUrl(library.ItemId, startIndex));
+            using var response = await client.SendAsync(request);
+            if (!response.IsSuccessStatusCode)
+            {
+                var responseBody = await response.Content.ReadAsStringAsync();
+                _logger.LogWarning("GET {Url} returned {StatusCode}: {Body}",
+                    request.RequestUri, response.StatusCode, responseBody);
+                return null;
+            }
+
+            var payload = await response.Content.ReadFromJsonAsync<JellyfinEmbyItemsResponse>();
+            var items = payload?.Items ?? [];
+
+            var match = items.FirstOrDefault(item => item.Path != null &&
+                                                     string.Equals(NormalizePath(item.Path), normalizedMediaPath,
+                                                         PathComparison));
+            if (match != null)
+            {
+                return match;
+            }
+
+            if (items.Count < ItemPageSize)
+            {
+                return null;
+            }
+        }
+    }
+
+    private async Task<bool> RefreshItem(HttpClient client, IApiCredentials config, string itemId)
+    {
+        var query = new Dictionary<string, string>
+        {
+            ["MetadataRefreshMode"] = "Default",
+            ["ImageRefreshMode"] = "None",
+            ["ReplaceAllMetadata"] = "false",
+            ["ReplaceAllImages"] = "false",
+            ["Recursive"] = "true",
+            ["RegenerateTrickplay"] = "false"
+        };
+
+        using var request = CreateRequest(config, HttpMethod.Post, $"/Items/{Uri.EscapeDataString(itemId)}/Refresh",
+            query);
+        using var response = await client.SendAsync(request);
+        if (response.IsSuccessStatusCode)
+        {
+            return true;
+        }
+
+        var responseBody = await response.Content.ReadAsStringAsync();
+        _logger.LogWarning("POST {Url} returned {StatusCode}: {Body}",
+            request.RequestUri, response.StatusCode, responseBody);
+        return false;
+    }
+
+    private async Task<bool> SendUpdatedMedia(HttpClient client, IApiCredentials config, string normalizedMediaPath)
+    {
+        using var request = CreateRequest(config, HttpMethod.Post, UpdatedMediaUrl);
+        request.Content = JsonContent.Create(new JellyfinEmbyMediaUpdateRequest
+        {
+            Updates =
+            [
+                new JellyfinEmbyMediaUpdate
+                {
+                    Path = normalizedMediaPath,
+                    UpdateType = "Modified"
+                }
+            ]
+        });
+
+        using var response = await client.SendAsync(request);
+        if (response.IsSuccessStatusCode)
+        {
+            return true;
+        }
+
+        var responseBody = await response.Content.ReadAsStringAsync();
+        _logger.LogWarning("POST {Url} returned {StatusCode}: {Body}",
+            request.RequestUri, response.StatusCode, responseBody);
+        return false;
+    }
+
+    private HttpRequestMessage CreateRequest(IApiCredentials config, HttpMethod method, string relativeUrl,
+        IReadOnlyDictionary<string, string>? query = null)
+    {
+        var request = new HttpRequestMessage(method, BuildUrl(config, relativeUrl, query));
+        request.Headers.TryAddWithoutValidation("X-Emby-Token", config.ApiKey.Trim());
+        request.Headers.TryAddWithoutValidation("Authorization", BuildAuthorizationHeader(config.ApiKey.Trim()));
+        request.Headers.TryAddWithoutValidation("Accept", "application/json");
+        return request;
+    }
+
+    private static string BuildItemsUrl(string libraryItemId, int startIndex)
+    {
+        var query = new Dictionary<string, string>
+        {
+            ["Recursive"] = "true",
+            ["Fields"] = "Path",
+            ["EnableImages"] = "false",
+            ["ParentId"] = libraryItemId,
+            ["EnableTotalRecordCount"] = "false",
+            ["Limit"] = ItemPageSize.ToString(),
+            ["StartIndex"] = startIndex.ToString()
+        };
+
+        return BuildRelativeUrl(ItemsUrl, query);
+    }
+
+    private static Uri BuildUrl(IApiCredentials config, string relativeUrl,
+        IReadOnlyDictionary<string, string>? query = null)
+    {
+        var baseUri = new Uri($"{config.Url.Trim().TrimEnd('/')}/");
+        var relative = BuildRelativeUrl(relativeUrl, query);
+        return new Uri(baseUri, relative.TrimStart('/'));
+    }
+
+    private static string BuildRelativeUrl(string relativeUrl, IReadOnlyDictionary<string, string>? query)
+    {
+        if (query == null || query.Count == 0)
+        {
+            return relativeUrl;
+        }
+
+        var queryString = string.Join("&",
+            query.Select(pair => $"{Uri.EscapeDataString(pair.Key)}={Uri.EscapeDataString(pair.Value)}"));
+        return $"{relativeUrl}?{queryString}";
+    }
+
+    private static bool MatchesLibrary(JellyfinEmbyLibrary library, string normalizedMediaPath)
+    {
+        return library.Locations.Any(location => IsPathWithin(normalizedMediaPath, NormalizePath(location)));
+    }
+
+    private static bool IsPathWithin(string path, string parent)
+    {
+        if (string.IsNullOrWhiteSpace(path) || string.IsNullOrWhiteSpace(parent))
+        {
+            return false;
+        }
+
+        if (!path.StartsWith(parent, PathComparison))
+        {
+            return false;
+        }
+
+        return path.Length == parent.Length || path[parent.Length] == '/';
+    }
+
+    private static string NormalizePath(string path)
+    {
+        return path.Replace('\\', '/').TrimEnd('/');
+    }
+
+    private static string BuildAuthorizationHeader(string apiKey)
+    {
+        var encodedApiKey = Uri.EscapeDataString(apiKey);
+        return
+            $"MediaBrowser Client=\"Muxarr\", Device=\"Muxarr\", DeviceId=\"muxarr\", Version=\"{ClientVersion}\", Token=\"{encodedApiKey}\"";
+    }
+
+    private static string GetClientVersion()
+    {
+        var version = Assembly.GetEntryAssembly()?.GetName().Version ??
+                      Assembly.GetExecutingAssembly().GetName().Version;
+        return version != null ? $"{version.Major}.{version.Minor}.{version.Build}" : "0.0.0";
+    }
+
+    private sealed class JellyfinEmbyLibrary
+    {
+        [JsonPropertyName("Name")] public string? Name { get; init; }
+        [JsonPropertyName("Locations")] public List<string> Locations { get; init; } = [];
+        [JsonPropertyName("ItemId")] public string? ItemId { get; init; }
+
+        public int LongestLocationLength =>
+            Locations.Count == 0 ? 0 : Locations.Max(location => NormalizePath(location).Length);
+    }
+
+    private sealed class JellyfinEmbyItemsResponse
+    {
+        [JsonPropertyName("Items")] public List<JellyfinEmbyItem> Items { get; init; } = [];
+    }
+
+    private sealed class JellyfinEmbyItem
+    {
+        [JsonPropertyName("Id")] public string? Id { get; init; }
+        [JsonPropertyName("Path")] public string? Path { get; init; }
+    }
+
+    private sealed class JellyfinEmbyMediaUpdateRequest
+    {
+        [JsonPropertyName("Updates")] public List<JellyfinEmbyMediaUpdate> Updates { get; init; } = [];
+    }
+
+    private sealed class JellyfinEmbyMediaUpdate
+    {
+        [JsonPropertyName("Path")] public string Path { get; init; } = string.Empty;
+        [JsonPropertyName("UpdateType")] public string UpdateType { get; init; } = "Modified";
+    }
+}

--- a/Muxarr.Core/Api/JellyfinEmbyApiClient.cs
+++ b/Muxarr.Core/Api/JellyfinEmbyApiClient.cs
@@ -1,7 +1,7 @@
 using System.Reflection;
 using System.Net.Http.Json;
-using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
+using Muxarr.Core.Api.Models;
 using Muxarr.Core.Config;
 
 namespace Muxarr.Core.Api;
@@ -28,102 +28,37 @@ public class JellyfinEmbyApiClient : IMediaServerClient
         _httpClientFactory = httpClientFactory;
     }
 
-    public Task<bool> CanConnect(IApiCredentials config)
+    public async Task<bool> CanConnect(IApiCredentials config)
     {
-        return Send(config, HttpMethod.Get, SystemInfoUrl);
+        return await Send(config, HttpMethod.Get, SystemInfoUrl);
     }
 
     public async Task<MediaServerUpdateResult> UpdateMedia(IApiCredentials config, string mediaPath)
     {
-        if (string.IsNullOrWhiteSpace(config.Url) || string.IsNullOrWhiteSpace(config.ApiKey))
+        var normalizedMediaPath = NormalizePath(mediaPath);
+
+        var libraries = await Get<List<JellyfinEmbyLibrary>>(config, VirtualFoldersUrl);
+        if (libraries == null)
         {
-            _logger.LogWarning("No valid media server url/apikey was found.");
             return MediaServerUpdateResult.Failed;
         }
 
-        var normalizedMediaPath = NormalizePath(mediaPath);
-
-        try
+        foreach (var library in libraries
+                     .Where(l => MatchesLibrary(l, normalizedMediaPath))
+                     .OrderByDescending(l => l.LongestLocationLength))
         {
-            using var client = _httpClientFactory.CreateClient(HttpClientName);
-
-            var libraries = await GetLibraries(client, config);
-            foreach (var library in libraries
-                         .Where(l => MatchesLibrary(l, normalizedMediaPath))
-                         .OrderByDescending(l => l.LongestLocationLength))
+            var item = await FindItemByPath(config, library, normalizedMediaPath);
+            if (item?.Id != null && await RefreshItem(config, item.Id))
             {
-                var item = await FindItemByPath(client, config, library, normalizedMediaPath);
-                if (item?.Id != null && await RefreshItem(client, config, item.Id))
-                {
-                    return MediaServerUpdateResult.ItemRefresh;
-                }
-            }
-
-            if (await SendUpdatedMedia(client, config, normalizedMediaPath))
-            {
-                return MediaServerUpdateResult.PathUpdate;
+                return MediaServerUpdateResult.ItemRefresh;
             }
         }
-        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or InvalidOperationException)
-        {
-            _logger.LogError(ex, "Failed to update media server for {Path}", mediaPath);
-        }
 
-        return MediaServerUpdateResult.Failed;
+        var sent = await SendUpdatedMedia(config, normalizedMediaPath);
+        return sent ? MediaServerUpdateResult.PathUpdate : MediaServerUpdateResult.Failed;
     }
 
-    private async Task<bool> Send(IApiCredentials config, HttpMethod method, string relativeUrl)
-    {
-        if (string.IsNullOrWhiteSpace(config.Url) || string.IsNullOrWhiteSpace(config.ApiKey))
-        {
-            _logger.LogWarning("No valid media server url/apikey was found.");
-            return false;
-        }
-
-        try
-        {
-            using var client = _httpClientFactory.CreateClient(HttpClientName);
-            using var request = CreateRequest(config, method, relativeUrl);
-            using var response = await client.SendAsync(request);
-            if (!response.IsSuccessStatusCode)
-            {
-                var responseBody = await response.Content.ReadAsStringAsync();
-                _logger.LogWarning("{Method} {Url} returned {StatusCode}: {Body}",
-                    method, request.RequestUri, response.StatusCode, responseBody);
-                return false;
-            }
-
-            return true;
-        }
-        catch (HttpRequestException ex)
-        {
-            _logger.LogError(ex, "HTTP error sending {Method} to {Url}", method, relativeUrl);
-            return false;
-        }
-        catch (TaskCanceledException ex)
-        {
-            _logger.LogWarning(ex, "Request to {Url} timed out", relativeUrl);
-            return false;
-        }
-    }
-
-    private async Task<List<JellyfinEmbyLibrary>> GetLibraries(HttpClient client, IApiCredentials config)
-    {
-        using var request = CreateRequest(config, HttpMethod.Get, VirtualFoldersUrl);
-        using var response = await client.SendAsync(request);
-        if (!response.IsSuccessStatusCode)
-        {
-            var responseBody = await response.Content.ReadAsStringAsync();
-            _logger.LogWarning("GET {Url} returned {StatusCode}: {Body}",
-                request.RequestUri, response.StatusCode, responseBody);
-            return [];
-        }
-
-        var libraries = await response.Content.ReadFromJsonAsync<List<JellyfinEmbyLibrary>>();
-        return libraries ?? [];
-    }
-
-    private async Task<JellyfinEmbyItem?> FindItemByPath(HttpClient client, IApiCredentials config,
+    private async Task<JellyfinEmbyItem?> FindItemByPath(IApiCredentials config,
         JellyfinEmbyLibrary library, string normalizedMediaPath)
     {
         if (string.IsNullOrWhiteSpace(library.ItemId))
@@ -133,17 +68,7 @@ public class JellyfinEmbyApiClient : IMediaServerClient
 
         for (var startIndex = 0;; startIndex += ItemPageSize)
         {
-            using var request = CreateRequest(config, HttpMethod.Get, BuildItemsUrl(library.ItemId, startIndex));
-            using var response = await client.SendAsync(request);
-            if (!response.IsSuccessStatusCode)
-            {
-                var responseBody = await response.Content.ReadAsStringAsync();
-                _logger.LogWarning("GET {Url} returned {StatusCode}: {Body}",
-                    request.RequestUri, response.StatusCode, responseBody);
-                return null;
-            }
-
-            var payload = await response.Content.ReadFromJsonAsync<JellyfinEmbyItemsResponse>();
+            var payload = await Get<JellyfinEmbyItemsResponse>(config, BuildItemsUrl(library.ItemId, startIndex));
             var items = payload?.Items ?? [];
 
             var match = items.FirstOrDefault(item => item.Path != null &&
@@ -161,7 +86,7 @@ public class JellyfinEmbyApiClient : IMediaServerClient
         }
     }
 
-    private async Task<bool> RefreshItem(HttpClient client, IApiCredentials config, string itemId)
+    private async Task<bool> RefreshItem(IApiCredentials config, string itemId)
     {
         var query = new Dictionary<string, string>
         {
@@ -173,45 +98,95 @@ public class JellyfinEmbyApiClient : IMediaServerClient
             ["RegenerateTrickplay"] = "false"
         };
 
-        using var request = CreateRequest(config, HttpMethod.Post, $"/Items/{Uri.EscapeDataString(itemId)}/Refresh",
-            query);
-        using var response = await client.SendAsync(request);
-        if (response.IsSuccessStatusCode)
-        {
-            return true;
-        }
-
-        var responseBody = await response.Content.ReadAsStringAsync();
-        _logger.LogWarning("POST {Url} returned {StatusCode}: {Body}",
-            request.RequestUri, response.StatusCode, responseBody);
-        return false;
+        return await Send(config, HttpMethod.Post, $"/Items/{Uri.EscapeDataString(itemId)}/Refresh", query: query);
     }
 
-    private async Task<bool> SendUpdatedMedia(HttpClient client, IApiCredentials config, string normalizedMediaPath)
+    private async Task<bool> SendUpdatedMedia(IApiCredentials config, string normalizedMediaPath)
     {
-        using var request = CreateRequest(config, HttpMethod.Post, UpdatedMediaUrl);
-        request.Content = JsonContent.Create(new JellyfinEmbyMediaUpdateRequest
-        {
-            Updates =
-            [
-                new JellyfinEmbyMediaUpdate
-                {
-                    Path = normalizedMediaPath,
-                    UpdateType = "Modified"
-                }
-            ]
-        });
+        return await Send(config, HttpMethod.Post, UpdatedMediaUrl, content: JsonContent.Create(
+            new JellyfinEmbyMediaUpdateRequest
+            {
+                Updates =
+                [
+                    new JellyfinEmbyMediaUpdate
+                    {
+                        Path = normalizedMediaPath,
+                        UpdateType = "Modified"
+                    }
+                ]
+            }));
+    }
 
-        using var response = await client.SendAsync(request);
-        if (response.IsSuccessStatusCode)
+    private async Task<T?> Get<T>(IApiCredentials config, string relativeUrl,
+        IReadOnlyDictionary<string, string>? query = null) where T : class
+    {
+        if (string.IsNullOrWhiteSpace(config.Url) || string.IsNullOrWhiteSpace(config.ApiKey))
         {
-            return true;
+            _logger.LogWarning("No valid {ParentClass} url/apikey was found.", GetType().Name);
+            return null;
         }
 
-        var responseBody = await response.Content.ReadAsStringAsync();
-        _logger.LogWarning("POST {Url} returned {StatusCode}: {Body}",
-            request.RequestUri, response.StatusCode, responseBody);
-        return false;
+        try
+        {
+            using var client = _httpClientFactory.CreateClient(HttpClientName);
+            using var request = CreateRequest(config, HttpMethod.Get, relativeUrl, query);
+            using var response = await client.SendAsync(request);
+            if (!response.IsSuccessStatusCode)
+            {
+                var responseBody = await response.Content.ReadAsStringAsync();
+                _logger.LogWarning("GET {Url} returned {StatusCode}: {Body}",
+                    request.RequestUri, response.StatusCode, responseBody);
+                return null;
+            }
+
+            return await response.Content.ReadFromJsonAsync<T>();
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "HTTP error requesting {Url}", relativeUrl);
+            return null;
+        }
+        catch (TaskCanceledException ex)
+        {
+            _logger.LogWarning(ex, "Request to {Url} timed out", relativeUrl);
+            return null;
+        }
+    }
+
+    private async Task<bool> Send(IApiCredentials config, HttpMethod method, string relativeUrl,
+        HttpContent? content = null, IReadOnlyDictionary<string, string>? query = null)
+    {
+        if (string.IsNullOrWhiteSpace(config.Url) || string.IsNullOrWhiteSpace(config.ApiKey))
+        {
+            _logger.LogWarning("No valid {ParentClass} url/apikey was found.", GetType().Name);
+            return false;
+        }
+
+        try
+        {
+            using var client = _httpClientFactory.CreateClient(HttpClientName);
+            using var request = CreateRequest(config, method, relativeUrl, query);
+            if (content != null)
+            {
+                request.Content = content;
+            }
+
+            using var response = await client.SendAsync(request);
+            if (response.IsSuccessStatusCode)
+            {
+                return true;
+            }
+
+            var responseBody = await response.Content.ReadAsStringAsync();
+            _logger.LogWarning("{Method} {Url} returned {StatusCode}: {Body}",
+                method, request.RequestUri, response.StatusCode, responseBody);
+            return false;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error sending {Method} to {Url}", method, relativeUrl);
+            return false;
+        }
     }
 
     private HttpRequestMessage CreateRequest(IApiCredentials config, HttpMethod method, string relativeUrl,
@@ -310,35 +285,4 @@ public class JellyfinEmbyApiClient : IMediaServerClient
         return version != null ? $"{version.Major}.{version.Minor}.{version.Build}" : "0.0.0";
     }
 
-    private sealed class JellyfinEmbyLibrary
-    {
-        [JsonPropertyName("Name")] public string? Name { get; init; }
-        [JsonPropertyName("Locations")] public List<string> Locations { get; init; } = [];
-        [JsonPropertyName("ItemId")] public string? ItemId { get; init; }
-
-        public int LongestLocationLength =>
-            Locations.Count == 0 ? 0 : Locations.Max(location => NormalizePath(location).Length);
-    }
-
-    private sealed class JellyfinEmbyItemsResponse
-    {
-        [JsonPropertyName("Items")] public List<JellyfinEmbyItem> Items { get; init; } = [];
-    }
-
-    private sealed class JellyfinEmbyItem
-    {
-        [JsonPropertyName("Id")] public string? Id { get; init; }
-        [JsonPropertyName("Path")] public string? Path { get; init; }
-    }
-
-    private sealed class JellyfinEmbyMediaUpdateRequest
-    {
-        [JsonPropertyName("Updates")] public List<JellyfinEmbyMediaUpdate> Updates { get; init; } = [];
-    }
-
-    private sealed class JellyfinEmbyMediaUpdate
-    {
-        [JsonPropertyName("Path")] public string Path { get; init; } = string.Empty;
-        [JsonPropertyName("UpdateType")] public string UpdateType { get; init; } = "Modified";
-    }
 }

--- a/Muxarr.Core/Api/JellyfinEmbyApiClient.cs
+++ b/Muxarr.Core/Api/JellyfinEmbyApiClient.cs
@@ -243,9 +243,20 @@ public class JellyfinEmbyApiClient : IMediaServerClient
     private static Uri BuildUrl(IApiCredentials config, string relativeUrl,
         IReadOnlyDictionary<string, string>? query = null)
     {
-        var baseUri = new Uri($"{config.Url.Trim().TrimEnd('/')}/");
+        var sanitizedBaseUrl = $"{config.Url.Trim().TrimEnd('/')}/";
+        if (!Uri.TryCreate(sanitizedBaseUrl, UriKind.Absolute, out var baseUri))
+        {
+            throw new UriFormatException($"Invalid media server URL: '{config.Url}'.");
+        }
+
         var relative = BuildRelativeUrl(relativeUrl, query);
-        return new Uri(baseUri, relative.TrimStart('/'));
+        if (!Uri.TryCreate(baseUri, relative.TrimStart('/'), out var requestUri))
+        {
+            throw new UriFormatException(
+                $"Invalid request URL. Base URL: '{config.Url}', relative URL: '{relativeUrl}'.");
+        }
+
+        return requestUri;
     }
 
     private static string BuildRelativeUrl(string relativeUrl, IReadOnlyDictionary<string, string>? query)

--- a/Muxarr.Core/Api/Models/JellyfinEmbyItem.cs
+++ b/Muxarr.Core/Api/Models/JellyfinEmbyItem.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace Muxarr.Core.Api.Models;
+
+public class JellyfinEmbyItem
+{
+    [JsonPropertyName("Id")]
+    public string? Id { get; init; }
+
+    [JsonPropertyName("Path")]
+    public string? Path { get; init; }
+}

--- a/Muxarr.Core/Api/Models/JellyfinEmbyItemsResponse.cs
+++ b/Muxarr.Core/Api/Models/JellyfinEmbyItemsResponse.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace Muxarr.Core.Api.Models;
+
+public class JellyfinEmbyItemsResponse
+{
+    [JsonPropertyName("Items")]
+    public List<JellyfinEmbyItem> Items { get; init; } = [];
+}

--- a/Muxarr.Core/Api/Models/JellyfinEmbyLibrary.cs
+++ b/Muxarr.Core/Api/Models/JellyfinEmbyLibrary.cs
@@ -1,0 +1,18 @@
+using System.Text.Json.Serialization;
+
+namespace Muxarr.Core.Api.Models;
+
+public class JellyfinEmbyLibrary
+{
+    [JsonPropertyName("Name")]
+    public string? Name { get; init; }
+
+    [JsonPropertyName("Locations")]
+    public List<string> Locations { get; init; } = [];
+
+    [JsonPropertyName("ItemId")]
+    public string? ItemId { get; init; }
+
+    public int LongestLocationLength =>
+        Locations.Count == 0 ? 0 : Locations.Max(location => location.Replace('\\', '/').TrimEnd('/').Length);
+}

--- a/Muxarr.Core/Api/Models/JellyfinEmbyMediaUpdate.cs
+++ b/Muxarr.Core/Api/Models/JellyfinEmbyMediaUpdate.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace Muxarr.Core.Api.Models;
+
+public class JellyfinEmbyMediaUpdate
+{
+    [JsonPropertyName("Path")]
+    public string Path { get; init; } = string.Empty;
+
+    [JsonPropertyName("UpdateType")]
+    public string UpdateType { get; init; } = "Modified";
+}

--- a/Muxarr.Core/Api/Models/JellyfinEmbyMediaUpdateRequest.cs
+++ b/Muxarr.Core/Api/Models/JellyfinEmbyMediaUpdateRequest.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace Muxarr.Core.Api.Models;
+
+public class JellyfinEmbyMediaUpdateRequest
+{
+    [JsonPropertyName("Updates")]
+    public List<JellyfinEmbyMediaUpdate> Updates { get; init; } = [];
+}

--- a/Muxarr.Core/Api/Models/PlexLibrarySection.cs
+++ b/Muxarr.Core/Api/Models/PlexLibrarySection.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace Muxarr.Core.Api.Models;
+
+public class PlexLibrarySection
+{
+    [JsonPropertyName("key")]
+    public string Key { get; init; } = string.Empty;
+
+    [JsonPropertyName("title")]
+    public string Title { get; init; } = string.Empty;
+
+    [JsonPropertyName("Location")]
+    public List<PlexLocation> Locations { get; init; } = [];
+}

--- a/Muxarr.Core/Api/Models/PlexLocation.cs
+++ b/Muxarr.Core/Api/Models/PlexLocation.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace Muxarr.Core.Api.Models;
+
+public class PlexLocation
+{
+    [JsonPropertyName("path")]
+    public string Path { get; init; } = string.Empty;
+}

--- a/Muxarr.Core/Api/Models/PlexMediaContainer.cs
+++ b/Muxarr.Core/Api/Models/PlexMediaContainer.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace Muxarr.Core.Api.Models;
+
+public class PlexMediaContainer
+{
+    [JsonPropertyName("MediaContainer")]
+    public PlexMediaContainerContent? MediaContainer { get; init; }
+}

--- a/Muxarr.Core/Api/Models/PlexMediaContainerContent.cs
+++ b/Muxarr.Core/Api/Models/PlexMediaContainerContent.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace Muxarr.Core.Api.Models;
+
+public class PlexMediaContainerContent
+{
+    [JsonPropertyName("Directory")]
+    public List<PlexLibrarySection> Directory { get; init; } = [];
+}

--- a/Muxarr.Core/Api/PlexApiClient.cs
+++ b/Muxarr.Core/Api/PlexApiClient.cs
@@ -37,6 +37,11 @@ public class PlexApiClient : IMediaServerClient
             using var response = await client.SendAsync(request);
             return response.IsSuccessStatusCode;
         }
+        catch (UriFormatException ex)
+        {
+            _logger.LogWarning(ex, "Invalid Plex URL configured: {Url}", config.Url);
+            return false;
+        }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {
             _logger.LogError(ex, "Failed to connect to Plex at {Url}", config.Url);
@@ -83,6 +88,10 @@ public class PlexApiClient : IMediaServerClient
                     return MediaServerUpdateResult.LibraryScan;
                 }
             }
+        }
+        catch (UriFormatException ex)
+        {
+            _logger.LogWarning(ex, "Invalid Plex URL configured: {Url}", config.Url);
         }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or InvalidOperationException)
         {
@@ -135,12 +144,27 @@ public class PlexApiClient : IMediaServerClient
 
     private static HttpRequestMessage CreateRequest(IApiCredentials config, HttpMethod method, string relativeUrl)
     {
-        var baseUri = new Uri($"{config.Url.Trim().TrimEnd('/')}/");
-        var uri = new Uri(baseUri, relativeUrl.TrimStart('/'));
-        var request = new HttpRequestMessage(method, uri);
+        var request = new HttpRequestMessage(method, BuildUrl(config, relativeUrl));
         request.Headers.TryAddWithoutValidation("X-Plex-Token", config.ApiKey.Trim());
         request.Headers.TryAddWithoutValidation("Accept", "application/json");
         return request;
+    }
+
+    private static Uri BuildUrl(IApiCredentials config, string relativeUrl)
+    {
+        var sanitizedBaseUrl = $"{config.Url.Trim().TrimEnd('/')}/";
+        if (!Uri.TryCreate(sanitizedBaseUrl, UriKind.Absolute, out var baseUri))
+        {
+            throw new UriFormatException($"Invalid media server URL: '{config.Url}'.");
+        }
+
+        if (!Uri.TryCreate(baseUri, relativeUrl.TrimStart('/'), out var requestUri))
+        {
+            throw new UriFormatException(
+                $"Invalid request URL. Base URL: '{config.Url}', relative URL: '{relativeUrl}'.");
+        }
+
+        return requestUri;
     }
 
     private static bool IsPathWithin(string path, string parent)

--- a/Muxarr.Core/Api/PlexApiClient.cs
+++ b/Muxarr.Core/Api/PlexApiClient.cs
@@ -1,0 +1,194 @@
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+using Muxarr.Core.Config;
+
+namespace Muxarr.Core.Api;
+
+public class PlexApiClient : IMediaServerClient
+{
+    private readonly ILogger<PlexApiClient> _logger;
+    private readonly IHttpClientFactory _httpClientFactory;
+
+    public const string HttpClientName = "Plex";
+
+    private const string IdentityUrl = "/identity";
+    private const string LibrarySectionsUrl = "/library/sections";
+    private static readonly StringComparison PathComparison =
+        OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+    public PlexApiClient(ILogger<PlexApiClient> logger, IHttpClientFactory httpClientFactory)
+    {
+        _logger = logger;
+        _httpClientFactory = httpClientFactory;
+    }
+
+    public async Task<bool> CanConnect(IApiCredentials config)
+    {
+        if (string.IsNullOrWhiteSpace(config.Url) || string.IsNullOrWhiteSpace(config.ApiKey))
+        {
+            return false;
+        }
+
+        try
+        {
+            using var client = _httpClientFactory.CreateClient(HttpClientName);
+            using var request = CreateRequest(config, HttpMethod.Get, IdentityUrl);
+            using var response = await client.SendAsync(request);
+            return response.IsSuccessStatusCode;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            _logger.LogError(ex, "Failed to connect to Plex at {Url}", config.Url);
+            return false;
+        }
+    }
+
+    public async Task<MediaServerUpdateResult> UpdateMedia(IApiCredentials config, string mediaPath)
+    {
+        if (string.IsNullOrWhiteSpace(config.Url) || string.IsNullOrWhiteSpace(config.ApiKey))
+        {
+            _logger.LogWarning("No valid Plex url/apikey was found.");
+            return MediaServerUpdateResult.Failed;
+        }
+
+        var normalizedMediaPath = NormalizePath(mediaPath);
+        var mediaDirectory = GetParentDirectory(normalizedMediaPath);
+
+        try
+        {
+            using var client = _httpClientFactory.CreateClient(HttpClientName);
+
+            var sections = await GetLibrarySections(client, config);
+            foreach (var section in sections)
+            {
+                var matchingLocation = section.Locations
+                    .FirstOrDefault(loc => IsPathWithin(normalizedMediaPath, NormalizePath(loc.Path)));
+
+                if (matchingLocation == null)
+                {
+                    continue;
+                }
+
+                // Targeted scan: refresh only the directory containing the file
+                if (!string.IsNullOrEmpty(mediaDirectory) &&
+                    await ScanLibrarySection(client, config, section.Key, mediaDirectory))
+                {
+                    return MediaServerUpdateResult.LibraryScan;
+                }
+
+                // Fallback: refresh the entire section
+                if (await ScanLibrarySection(client, config, section.Key, null))
+                {
+                    return MediaServerUpdateResult.LibraryScan;
+                }
+            }
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or InvalidOperationException)
+        {
+            _logger.LogError(ex, "Failed to update Plex media for {Path}", mediaPath);
+        }
+
+        return MediaServerUpdateResult.Failed;
+    }
+
+    private async Task<List<PlexLibrarySection>> GetLibrarySections(HttpClient client, IApiCredentials config)
+    {
+        using var request = CreateRequest(config, HttpMethod.Get, LibrarySectionsUrl);
+        request.Headers.TryAddWithoutValidation("Accept", "application/json");
+        using var response = await client.SendAsync(request);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var responseBody = await response.Content.ReadAsStringAsync();
+            _logger.LogWarning("GET {Url} returned {StatusCode}: {Body}",
+                request.RequestUri, response.StatusCode, responseBody);
+            return [];
+        }
+
+        var container = await response.Content.ReadFromJsonAsync<PlexMediaContainer>();
+        return container?.MediaContainer?.Directory ?? [];
+    }
+
+    private async Task<bool> ScanLibrarySection(HttpClient client, IApiCredentials config,
+        string sectionKey, string? path)
+    {
+        var url = $"{LibrarySectionsUrl}/{Uri.EscapeDataString(sectionKey)}/refresh";
+        if (!string.IsNullOrEmpty(path))
+        {
+            url += $"?path={Uri.EscapeDataString(path)}";
+        }
+
+        using var request = CreateRequest(config, HttpMethod.Get, url);
+        using var response = await client.SendAsync(request);
+
+        if (response.IsSuccessStatusCode)
+        {
+            return true;
+        }
+
+        var responseBody = await response.Content.ReadAsStringAsync();
+        _logger.LogWarning("GET {Url} returned {StatusCode}: {Body}",
+            request.RequestUri, response.StatusCode, responseBody);
+        return false;
+    }
+
+    private static HttpRequestMessage CreateRequest(IApiCredentials config, HttpMethod method, string relativeUrl)
+    {
+        var baseUri = new Uri($"{config.Url.Trim().TrimEnd('/')}/");
+        var uri = new Uri(baseUri, relativeUrl.TrimStart('/'));
+        var request = new HttpRequestMessage(method, uri);
+        request.Headers.TryAddWithoutValidation("X-Plex-Token", config.ApiKey.Trim());
+        request.Headers.TryAddWithoutValidation("Accept", "application/json");
+        return request;
+    }
+
+    private static bool IsPathWithin(string path, string parent)
+    {
+        if (string.IsNullOrWhiteSpace(path) || string.IsNullOrWhiteSpace(parent))
+        {
+            return false;
+        }
+
+        if (!path.StartsWith(parent, PathComparison))
+        {
+            return false;
+        }
+
+        return path.Length == parent.Length || path[parent.Length] == '/';
+    }
+
+    private static string NormalizePath(string path)
+    {
+        return path.Replace('\\', '/').TrimEnd('/');
+    }
+
+    private static string? GetParentDirectory(string normalizedPath)
+    {
+        var lastSlash = normalizedPath.LastIndexOf('/');
+        return lastSlash > 0 ? normalizedPath[..lastSlash] : null;
+    }
+
+    // Plex JSON response models
+    private sealed class PlexMediaContainer
+    {
+        [JsonPropertyName("MediaContainer")] public PlexMediaContainerContent? MediaContainer { get; init; }
+    }
+
+    private sealed class PlexMediaContainerContent
+    {
+        [JsonPropertyName("Directory")] public List<PlexLibrarySection> Directory { get; init; } = [];
+    }
+
+    private sealed class PlexLibrarySection
+    {
+        [JsonPropertyName("key")] public string Key { get; init; } = string.Empty;
+        [JsonPropertyName("title")] public string Title { get; init; } = string.Empty;
+        [JsonPropertyName("Location")] public List<PlexLocation> Locations { get; init; } = [];
+    }
+
+    private sealed class PlexLocation
+    {
+        [JsonPropertyName("path")] public string Path { get; init; } = string.Empty;
+    }
+}

--- a/Muxarr.Core/Api/PlexApiClient.cs
+++ b/Muxarr.Core/Api/PlexApiClient.cs
@@ -1,6 +1,6 @@
 using System.Net.Http.Json;
-using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
+using Muxarr.Core.Api.Models;
 using Muxarr.Core.Config;
 
 namespace Muxarr.Core.Api;
@@ -25,102 +25,45 @@ public class PlexApiClient : IMediaServerClient
 
     public async Task<bool> CanConnect(IApiCredentials config)
     {
-        if (string.IsNullOrWhiteSpace(config.Url) || string.IsNullOrWhiteSpace(config.ApiKey))
-        {
-            return false;
-        }
-
-        try
-        {
-            using var client = _httpClientFactory.CreateClient(HttpClientName);
-            using var request = CreateRequest(config, HttpMethod.Get, IdentityUrl);
-            using var response = await client.SendAsync(request);
-            return response.IsSuccessStatusCode;
-        }
-        catch (UriFormatException ex)
-        {
-            _logger.LogWarning(ex, "Invalid Plex URL configured: {Url}", config.Url);
-            return false;
-        }
-        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
-        {
-            _logger.LogError(ex, "Failed to connect to Plex at {Url}", config.Url);
-            return false;
-        }
+        return await Send(config, HttpMethod.Get, IdentityUrl);
     }
 
     public async Task<MediaServerUpdateResult> UpdateMedia(IApiCredentials config, string mediaPath)
     {
-        if (string.IsNullOrWhiteSpace(config.Url) || string.IsNullOrWhiteSpace(config.ApiKey))
-        {
-            _logger.LogWarning("No valid Plex url/apikey was found.");
-            return MediaServerUpdateResult.Failed;
-        }
-
         var normalizedMediaPath = NormalizePath(mediaPath);
         var mediaDirectory = GetParentDirectory(normalizedMediaPath);
 
-        try
-        {
-            using var client = _httpClientFactory.CreateClient(HttpClientName);
+        var container = await Get<PlexMediaContainer>(config, LibrarySectionsUrl);
+        var sections = container?.MediaContainer?.Directory ?? [];
 
-            var sections = await GetLibrarySections(client, config);
-            foreach (var section in sections)
+        foreach (var section in sections)
+        {
+            var matchingLocation = section.Locations
+                .FirstOrDefault(loc => IsPathWithin(normalizedMediaPath, NormalizePath(loc.Path)));
+
+            if (matchingLocation == null)
             {
-                var matchingLocation = section.Locations
-                    .FirstOrDefault(loc => IsPathWithin(normalizedMediaPath, NormalizePath(loc.Path)));
-
-                if (matchingLocation == null)
-                {
-                    continue;
-                }
-
-                // Targeted scan: refresh only the directory containing the file
-                if (!string.IsNullOrEmpty(mediaDirectory) &&
-                    await ScanLibrarySection(client, config, section.Key, mediaDirectory))
-                {
-                    return MediaServerUpdateResult.LibraryScan;
-                }
-
-                // Fallback: refresh the entire section
-                if (await ScanLibrarySection(client, config, section.Key, null))
-                {
-                    return MediaServerUpdateResult.LibraryScan;
-                }
+                continue;
             }
-        }
-        catch (UriFormatException ex)
-        {
-            _logger.LogWarning(ex, "Invalid Plex URL configured: {Url}", config.Url);
-        }
-        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or InvalidOperationException)
-        {
-            _logger.LogError(ex, "Failed to update Plex media for {Path}", mediaPath);
+
+            // Targeted scan: refresh only the directory containing the file
+            if (!string.IsNullOrEmpty(mediaDirectory) &&
+                await ScanLibrarySection(config, section.Key, mediaDirectory))
+            {
+                return MediaServerUpdateResult.LibraryScan;
+            }
+
+            // Fallback: refresh the entire section
+            if (await ScanLibrarySection(config, section.Key, null))
+            {
+                return MediaServerUpdateResult.LibraryScan;
+            }
         }
 
         return MediaServerUpdateResult.Failed;
     }
 
-    private async Task<List<PlexLibrarySection>> GetLibrarySections(HttpClient client, IApiCredentials config)
-    {
-        using var request = CreateRequest(config, HttpMethod.Get, LibrarySectionsUrl);
-        request.Headers.TryAddWithoutValidation("Accept", "application/json");
-        using var response = await client.SendAsync(request);
-
-        if (!response.IsSuccessStatusCode)
-        {
-            var responseBody = await response.Content.ReadAsStringAsync();
-            _logger.LogWarning("GET {Url} returned {StatusCode}: {Body}",
-                request.RequestUri, response.StatusCode, responseBody);
-            return [];
-        }
-
-        var container = await response.Content.ReadFromJsonAsync<PlexMediaContainer>();
-        return container?.MediaContainer?.Directory ?? [];
-    }
-
-    private async Task<bool> ScanLibrarySection(HttpClient client, IApiCredentials config,
-        string sectionKey, string? path)
+    private async Task<bool> ScanLibrarySection(IApiCredentials config, string sectionKey, string? path)
     {
         var url = $"{LibrarySectionsUrl}/{Uri.EscapeDataString(sectionKey)}/refresh";
         if (!string.IsNullOrEmpty(path))
@@ -128,18 +71,72 @@ public class PlexApiClient : IMediaServerClient
             url += $"?path={Uri.EscapeDataString(path)}";
         }
 
-        using var request = CreateRequest(config, HttpMethod.Get, url);
-        using var response = await client.SendAsync(request);
+        return await Send(config, HttpMethod.Get, url);
+    }
 
-        if (response.IsSuccessStatusCode)
+    private async Task<T?> Get<T>(IApiCredentials config, string relativeUrl) where T : class
+    {
+        if (string.IsNullOrWhiteSpace(config.Url) || string.IsNullOrWhiteSpace(config.ApiKey))
         {
-            return true;
+            _logger.LogWarning("No valid {ParentClass} url/apikey was found.", GetType().Name);
+            return null;
         }
 
-        var responseBody = await response.Content.ReadAsStringAsync();
-        _logger.LogWarning("GET {Url} returned {StatusCode}: {Body}",
-            request.RequestUri, response.StatusCode, responseBody);
-        return false;
+        try
+        {
+            using var client = _httpClientFactory.CreateClient(HttpClientName);
+            using var request = CreateRequest(config, HttpMethod.Get, relativeUrl);
+            using var response = await client.SendAsync(request);
+            if (!response.IsSuccessStatusCode)
+            {
+                var responseBody = await response.Content.ReadAsStringAsync();
+                _logger.LogWarning("GET {Url} returned {StatusCode}: {Body}",
+                    request.RequestUri, response.StatusCode, responseBody);
+                return null;
+            }
+
+            return await response.Content.ReadFromJsonAsync<T>();
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "HTTP error requesting {Url}", relativeUrl);
+            return null;
+        }
+        catch (TaskCanceledException ex)
+        {
+            _logger.LogWarning(ex, "Request to {Url} timed out", relativeUrl);
+            return null;
+        }
+    }
+
+    private async Task<bool> Send(IApiCredentials config, HttpMethod method, string relativeUrl)
+    {
+        if (string.IsNullOrWhiteSpace(config.Url) || string.IsNullOrWhiteSpace(config.ApiKey))
+        {
+            _logger.LogWarning("No valid {ParentClass} url/apikey was found.", GetType().Name);
+            return false;
+        }
+
+        try
+        {
+            using var client = _httpClientFactory.CreateClient(HttpClientName);
+            using var request = CreateRequest(config, method, relativeUrl);
+            using var response = await client.SendAsync(request);
+            if (response.IsSuccessStatusCode)
+            {
+                return true;
+            }
+
+            var responseBody = await response.Content.ReadAsStringAsync();
+            _logger.LogWarning("{Method} {Url} returned {StatusCode}: {Body}",
+                method, request.RequestUri, response.StatusCode, responseBody);
+            return false;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error sending {Method} to {Url}", method, relativeUrl);
+            return false;
+        }
     }
 
     private static HttpRequestMessage CreateRequest(IApiCredentials config, HttpMethod method, string relativeUrl)
@@ -193,26 +190,4 @@ public class PlexApiClient : IMediaServerClient
         return lastSlash > 0 ? normalizedPath[..lastSlash] : null;
     }
 
-    // Plex JSON response models
-    private sealed class PlexMediaContainer
-    {
-        [JsonPropertyName("MediaContainer")] public PlexMediaContainerContent? MediaContainer { get; init; }
-    }
-
-    private sealed class PlexMediaContainerContent
-    {
-        [JsonPropertyName("Directory")] public List<PlexLibrarySection> Directory { get; init; } = [];
-    }
-
-    private sealed class PlexLibrarySection
-    {
-        [JsonPropertyName("key")] public string Key { get; init; } = string.Empty;
-        [JsonPropertyName("title")] public string Title { get; init; } = string.Empty;
-        [JsonPropertyName("Location")] public List<PlexLocation> Locations { get; init; } = [];
-    }
-
-    private sealed class PlexLocation
-    {
-        [JsonPropertyName("path")] public string Path { get; init; } = string.Empty;
-    }
 }

--- a/Muxarr.Core/Config/ProcessingConfig.cs
+++ b/Muxarr.Core/Config/ProcessingConfig.cs
@@ -5,6 +5,8 @@ public class ProcessingConfig
     public int ScanIntervalMinutes { get; set; }
     public int ConversionTimeoutMinutes { get; set; } = 60;
 
+    public bool MediaServerRefreshEnabled { get; set; }
+
     public bool PostProcessingEnabled { get; set; }
     public string PostProcessingCommand { get; set; } = string.Empty;
 

--- a/Muxarr.Data/Entities/Integration.cs
+++ b/Muxarr.Data/Entities/Integration.cs
@@ -7,7 +7,10 @@ namespace Muxarr.Data.Entities;
 public enum IntegrationType
 {
     Sonarr,
-    Radarr
+    Radarr,
+    Jellyfin,
+    Emby,
+    Plex
 }
 
 public class Integration : AuditableEntity, IApiCredentials
@@ -19,6 +22,12 @@ public class Integration : AuditableEntity, IApiCredentials
     public string ApiKey { get; set; } = string.Empty;
 
     public List<MediaInfo> MediaInfos { get; set; } = [];
+
+    public static bool IsArrServiceType(IntegrationType type) =>
+        type is IntegrationType.Sonarr or IntegrationType.Radarr;
+
+    public static bool IsMediaServerType(IntegrationType type) =>
+        type is IntegrationType.Jellyfin or IntegrationType.Emby or IntegrationType.Plex;
 }
 
 public class IntegrationConfiguration : AuditEntityConfiguration<Integration>

--- a/Muxarr.Web/Components/Pages/Settings/ConnectionsSettingsTab.razor
+++ b/Muxarr.Web/Components/Pages/Settings/ConnectionsSettingsTab.razor
@@ -18,7 +18,7 @@
     </div>
 
     <div class="row g-4 mb-4">
-        @foreach (var svc in Services)
+        @foreach (var svc in ArrServices)
         {
             <div class="col-lg-6">
                 <ArrServiceCard Service="svc"
@@ -37,6 +37,31 @@
         </button>
         <button type="button" class="btn btn-outline-primary btn-sm" @onclick="() => AddService(IntegrationType.Radarr)">
             <i class="bi bi-plus-circle me-1"></i>Add Radarr
+        </button>
+    </div>
+
+    <div class="row g-4 mb-4">
+        @foreach (var svc in MediaServerServices)
+        {
+            <div class="col-lg-6">
+                <MediaServerCard Service="svc"
+                                    ShowName="true"
+                                    CanDelete="true"
+                                    AutoSave="@SaveSettingsSilent"
+                                    OnDelete="@(() => RemoveService(svc))"/>
+            </div>
+        }
+    </div>
+
+    <div class="d-flex gap-2 mb-4">
+        <button type="button" class="btn btn-outline-primary btn-sm" @onclick="() => AddService(IntegrationType.Jellyfin)">
+            <i class="bi bi-plus-circle me-1"></i>Add Jellyfin
+        </button>
+        <button type="button" class="btn btn-outline-primary btn-sm" @onclick="() => AddService(IntegrationType.Emby)">
+            <i class="bi bi-plus-circle me-1"></i>Add Emby
+        </button>
+        <button type="button" class="btn btn-outline-primary btn-sm" @onclick="() => AddService(IntegrationType.Plex)">
+            <i class="bi bi-plus-circle me-1"></i>Add Plex
         </button>
     </div>
 
@@ -74,6 +99,8 @@
 
     private List<Integration> Services { get; set; } = [];
     private WebhookConfig WebhookConfig { get; set; } = new();
+    private IEnumerable<Integration> ArrServices => Services.Where(s => Integration.IsArrServiceType(s.Type));
+    private IEnumerable<Integration> MediaServerServices => Services.Where(s => Integration.IsMediaServerType(s.Type));
 
     private string WebhookUrl
     {
@@ -131,7 +158,7 @@
 
     private void AddService(IntegrationType type)
     {
-        var name = type == IntegrationType.Sonarr ? "Sonarr" : "Radarr";
+        var name = type.ToString();
         name += $" {Services.Count(c => c.Type == type) + 1}";
 
         Services.Add(new Integration { Name = name, Type = type });
@@ -189,7 +216,7 @@
             {
                 if (string.IsNullOrWhiteSpace(svc.Name))
                 {
-                    svc.Name = svc.Type == IntegrationType.Sonarr ? "Sonarr" : "Radarr";
+                    svc.Name = svc.Type.ToString();
                 }
 
                 svc.Url = svc.Url.SanitizeUrl();

--- a/Muxarr.Web/Components/Pages/Settings/MediaServerCard.razor
+++ b/Muxarr.Web/Components/Pages/Settings/MediaServerCard.razor
@@ -1,0 +1,216 @@
+@using Muxarr.Core.Api
+@using Muxarr.Data.Entities
+<div class="border rounded p-4">
+    @if (ShowTypeSelector)
+    {
+        <div class="mb-3">
+            <h5 class="mb-3"><i class="bi bi-collection-play text-primary me-2"></i>Media Server</h5>
+            <div class="btn-group w-100" role="group">
+                <button type="button" class="btn @(CurrentType == IntegrationType.Jellyfin ? "btn-primary" : "btn-outline-primary") btn-sm"
+                        @onclick="() => SelectType(IntegrationType.Jellyfin)">Jellyfin</button>
+                <button type="button" class="btn @(CurrentType == IntegrationType.Emby ? "btn-primary" : "btn-outline-primary") btn-sm"
+                        @onclick="() => SelectType(IntegrationType.Emby)">Emby</button>
+                <button type="button" class="btn @(CurrentType == IntegrationType.Plex ? "btn-primary" : "btn-outline-primary") btn-sm"
+                        @onclick="() => SelectType(IntegrationType.Plex)">Plex</button>
+            </div>
+        </div>
+    }
+
+    <div class="d-flex flex-wrap align-items-center gap-1 mb-3">
+        <i class="bi @GetIconClass(CurrentType) text-primary me-2"></i>
+        <h5 class="mb-0">@(!string.IsNullOrWhiteSpace(Service.Name) && ShowName ? Service.Name : CurrentType?.ToString() ?? "Media Server")</h5>
+        @if (_isConnected != null)
+        {
+            <span class="badge @(_isConnected.Value ? "text-bg-success" : "text-bg-danger")">
+                <i class="bi @(_isConnected.Value ? "bi-check-circle" : "bi-x-circle") me-1"></i>@(_isConnected.Value ? "Connected" : "Not Connected")
+            </span>
+        }
+    </div>
+
+    @if (ShowName)
+    {
+        <div class="mb-3">
+            <label for="@($"name-{ElementId}")" class="form-label">Name</label>
+            <InputText id="@($"name-{ElementId}")" class="form-control" @bind-Value="Service.Name"/>
+        </div>
+    }
+
+    <div class="mb-3">
+        <label for="@($"url-{ElementId}")" class="form-label">URL</label>
+        <InputText id="@($"url-{ElementId}")" class="form-control" placeholder="@GetUrlPlaceholder(CurrentType)"
+                   disabled="@(CurrentType is null)" @bind-Value="Service.Url"/>
+    </div>
+
+    <div class="mb-2">
+        <label for="@($"apiKey-{ElementId}")" class="form-label">API Key</label>
+        <InputText id="@($"apiKey-{ElementId}")" class="form-control" disabled="@(CurrentType is null)" @bind-Value="Service.ApiKey"/>
+        <small class="form-text text-muted">@GetApiKeyHint(CurrentType)</small>
+    </div>
+
+    <p class="text-muted small mb-3">Lets Muxarr automatically refresh your library after processing files. Enable this in the Processing tab.</p>
+
+    <div class="d-flex gap-2 flex-wrap">
+        <button type="button" class="btn btn-outline-primary btn-sm" @onclick="TestConnection" disabled="@(_isBusy || CurrentType is null)">
+            @if (_isBusy)
+            {
+                <span class="spinner-border spinner-border-sm me-1" role="status"></span>
+            }
+            <i class="bi bi-plug me-1"></i>Test Connection
+        </button>
+
+        @if (CanDelete)
+        {
+            <button type="button" class="btn btn-outline-danger btn-sm" @onclick="OnDelete" disabled="@_isBusy">
+                <i class="bi bi-trash me-1"></i>Remove
+            </button>
+        }
+    </div>
+</div>
+
+@code {
+    private string ElementId => Service.Id != 0 ? Service.Id.ToString() : Service.GetHashCode().ToString();
+    private IntegrationType? CurrentType => SelectedType ?? (Integration.IsMediaServerType(Service.Type) ? Service.Type : null);
+
+    private bool _isBusy;
+    private bool? _isConnected;
+
+    [Parameter] [EditorRequired] public required Integration Service { get; set; }
+    [Parameter] public bool ShowTypeSelector { get; set; }
+    [Parameter] public IntegrationType? SelectedType { get; set; }
+    [Parameter] public EventCallback<IntegrationType> OnTypeSelected { get; set; }
+    [Parameter] public bool ShowName { get; set; }
+    [Parameter] public bool CanDelete { get; set; }
+    [Parameter] public Func<Task>? AutoSave { get; set; }
+    [Parameter] public EventCallback OnDelete { get; set; }
+
+    [Inject] public required MediaServerClientFactory MediaServerClientFactory { get; set; }
+    [Inject] public required IToastService ToastService { get; set; }
+
+    private async Task SelectType(IntegrationType type)
+    {
+        if (!ShowTypeSelector || CurrentType == type)
+        {
+            return;
+        }
+
+        _isConnected = null;
+
+        if (OnTypeSelected.HasDelegate)
+        {
+            await OnTypeSelected.InvokeAsync(type);
+        }
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (string.IsNullOrWhiteSpace(Service.Url) || string.IsNullOrWhiteSpace(Service.ApiKey))
+        {
+            return;
+        }
+
+        if (CurrentType is not { } currentType)
+        {
+            return;
+        }
+
+        var client = MediaServerClientFactory.GetClient(currentType);
+        if (client == null)
+        {
+            return;
+        }
+
+        try
+        {
+            _isConnected = await client.CanConnect(Service);
+        }
+        catch
+        {
+            _isConnected = false;
+        }
+    }
+
+    private async Task TestConnection()
+    {
+        if (CurrentType is not { } currentType)
+        {
+            ToastService.ShowWarning("Select Jellyfin, Emby, or Plex first.");
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(Service.Url) || string.IsNullOrWhiteSpace(Service.ApiKey))
+        {
+            ToastService.ShowWarning($"Please enter a URL and API key for {currentType}.");
+            return;
+        }
+
+        var client = MediaServerClientFactory.GetClient(currentType);
+        if (client == null)
+        {
+            ToastService.ShowError($"No API client available for {currentType}.");
+            return;
+        }
+
+        _isBusy = true;
+        _isConnected = null;
+        StateHasChanged();
+
+        try
+        {
+            if (AutoSave != null)
+            {
+                await AutoSave();
+            }
+
+            Service.Url = Service.Url.SanitizeUrl();
+            _isConnected = await client.CanConnect(Service);
+
+            if (_isConnected == true)
+            {
+                ToastService.ShowSuccess($"{currentType} connection successful!");
+            }
+            else
+            {
+                ToastService.ShowError($"Could not connect to {currentType}. Check URL and API key.");
+            }
+        }
+        catch
+        {
+            _isConnected = false;
+            ToastService.ShowError($"Could not connect to {currentType}. Check URL and API key.");
+        }
+        finally
+        {
+            _isBusy = false;
+        }
+    }
+
+    private static string GetIconClass(IntegrationType? type) => type switch
+    {
+        IntegrationType.Jellyfin => "bi-collection-play",
+        IntegrationType.Emby => "bi-collection-play",
+        IntegrationType.Plex => "bi-collection-play",
+        IntegrationType.Sonarr => "bi-tv",
+        IntegrationType.Radarr => "bi-film",
+        _ => "bi-app"
+    };
+
+    private static string GetUrlPlaceholder(IntegrationType? type) => type switch
+    {
+        IntegrationType.Jellyfin => "http://jellyfin:8096",
+        IntegrationType.Emby => "http://emby:8096",
+        IntegrationType.Plex => "http://plex:32400",
+        IntegrationType.Sonarr => "http://sonarr:8989",
+        IntegrationType.Radarr => "http://radarr:7878",
+        _ => "http://localhost"
+    };
+
+    private static string GetApiKeyHint(IntegrationType? type) => type switch
+    {
+        IntegrationType.Jellyfin => "Found in Jellyfin > Dashboard > API Keys",
+        IntegrationType.Emby => "Found in Emby > Server > API Keys",
+        IntegrationType.Plex => "Found in Plex > Settings > Account > X-Plex-Token (or use a Plex token)",
+        IntegrationType.Sonarr => "Found in Sonarr > Settings > General > Security",
+        IntegrationType.Radarr => "Found in Radarr > Settings > General > Security",
+        _ => "Select Jellyfin, Emby, or Plex first."
+    };
+}

--- a/Muxarr.Web/Components/Pages/Settings/ProcessingSettingsTab.razor
+++ b/Muxarr.Web/Components/Pages/Settings/ProcessingSettingsTab.razor
@@ -71,6 +71,17 @@
     </div>
 
     <div class="border rounded p-4 mb-4">
+        <h5 class="mb-3"><i class="bi bi-collection-play me-2"></i>Media Server</h5>
+        <p class="text-muted small mb-3">Tell your media server to update its library after Muxarr finishes processing a file, so your changes show up right away.</p>
+
+        <div class="mb-3 form-check form-switch">
+            <InputCheckbox id="ms-enabled" class="form-check-input" @bind-Value="ProcessingConfig.MediaServerRefreshEnabled"/>
+            <label for="ms-enabled" class="form-check-label">Refresh media server after conversion</label>
+        </div>
+
+    </div>
+
+    <div class="border rounded p-4 mb-4">
         <h5 class="mb-3"><i class="bi bi-terminal me-2"></i>Post-Processing</h5>
         <p class="text-muted small mb-3">Run a custom command after each successful conversion. Useful for refreshing
             media servers, cleaning subtitles, or other automation.</p>

--- a/Muxarr.Web/Components/Pages/Setup.razor
+++ b/Muxarr.Web/Components/Pages/Setup.razor
@@ -52,11 +52,11 @@
     }
     else if (_step == 2)
     {
-        <h4 class="mb-2">Connect Sonarr & Radarr</h4>
+        <h4 class="mb-2">Connect Your Apps</h4>
         <p class="text-muted small mb-4">
-            Optionally connect your Sonarr and Radarr instances. Muxarr uses these to automatically
-            process files when imported or renamed, and to retrieve original language metadata for
-            smarter track filtering. You can always configure this later in Settings.
+            Optionally connect your Sonarr, Radarr and Media Server instances. Muxarr uses these to automatically
+            process files when imported or renamed, to retrieve original language metadata for
+            smarter track filtering and to refresh your media server library. You can always configure this later in Settings.
         </p>
 
         <EditForm Model="_sonarrService" FormName="arr-setup">
@@ -79,6 +79,13 @@
                     <ArrServiceCard Service="_radarrService"
                                     GetWebhookUrl="@GetWebhookUrl"
                                     AutoSave="@PersistConnections"/>
+                </div>
+                <div class="col-md-6">
+                    <MediaServerCard Service="_mediaServerService"
+                                     ShowTypeSelector="true"
+                                     SelectedType="_mediaServerType"
+                                     OnTypeSelected="SetMediaServerType"
+                                     AutoSave="@PersistConnections"/>
                 </div>
             </div>
 
@@ -144,6 +151,8 @@
     private string? _error;
     private Integration _sonarrService = new() { Name = "Sonarr", Type = IntegrationType.Sonarr };
     private Integration _radarrService = new() { Name = "Radarr", Type = IntegrationType.Radarr };
+    private Integration _mediaServerService = new();
+    private IntegrationType? _mediaServerType;
 
     private string GetWebhookUrl()
     {
@@ -173,6 +182,7 @@
         var existing = await context.Integrations.ToListAsync();
         var sonarr = existing.FirstOrDefault(c => c.Type == IntegrationType.Sonarr);
         var radarr = existing.FirstOrDefault(c => c.Type == IntegrationType.Radarr);
+        var mediaServer = existing.FirstOrDefault(c => Integration.IsMediaServerType(c.Type));
         if (sonarr != null)
         {
             _sonarrService = sonarr;
@@ -180,6 +190,11 @@
         if (radarr != null)
         {
             _radarrService = radarr;
+        }
+        if (mediaServer != null)
+        {
+            _mediaServerService = mediaServer;
+            _mediaServerType = mediaServer.Type;
         }
 
         var webhookConfig = context.Configs.GetOrDefault<WebhookConfig>();
@@ -233,6 +248,20 @@
         GoToStep(2);
     }
 
+    private void SetMediaServerType(IntegrationType type)
+    {
+        if (_mediaServerType == type)
+        {
+            return;
+        }
+
+        _mediaServerType = type;
+        _mediaServerService.Name = type.ToString();
+        _mediaServerService.Type = type;
+        _mediaServerService.Url = string.Empty;
+        _mediaServerService.ApiKey = string.Empty;
+    }
+
     private async Task SaveAndContinue()
     {
         await PersistConnections();
@@ -258,6 +287,29 @@
                 {
                     existing.Url = svc.Url;
                     existing.ApiKey = svc.ApiKey;
+                }
+            }
+        }
+
+        if (_mediaServerType.HasValue)
+        {
+            _mediaServerService.Name = _mediaServerType.Value.ToString();
+            _mediaServerService.Type = _mediaServerType.Value;
+            _mediaServerService.Url = _mediaServerService.Url.SanitizeUrl();
+
+            if (_mediaServerService.Id == 0)
+            {
+                context.Integrations.Add(_mediaServerService);
+            }
+            else
+            {
+                var existingMediaServer = await context.Integrations.FindAsync(_mediaServerService.Id);
+                if (existingMediaServer != null)
+                {
+                    existingMediaServer.Name = _mediaServerService.Name;
+                    existingMediaServer.Type = _mediaServerService.Type;
+                    existingMediaServer.Url = _mediaServerService.Url;
+                    existingMediaServer.ApiKey = _mediaServerService.ApiKey;
                 }
             }
         }

--- a/Muxarr.Web/Program.cs
+++ b/Muxarr.Web/Program.cs
@@ -32,12 +32,17 @@ await builder.RunWithLoggingAsync(async b =>
     b.Services.AddDataProtection()
         .PersistKeysToDbContext<AppDbContext>();
     b.Services.AddHttpClient(ArrApiClient.HttpClientName, client => { client.Timeout = TimeSpan.FromSeconds(10); });
+    b.Services.AddHttpClient(JellyfinEmbyApiClient.HttpClientName, client => { client.Timeout = TimeSpan.FromSeconds(10); });
+    b.Services.AddHttpClient(PlexApiClient.HttpClientName, client => { client.Timeout = TimeSpan.FromSeconds(10); });
 
     // Authentication & rate limiting
     b.Services.AddMuxarrAuthentication();
 
     // Background services
     b.Services.AddSingleton<ArrApiClient>();
+    b.Services.AddSingleton<JellyfinEmbyApiClient>();
+    b.Services.AddSingleton<PlexApiClient>();
+    b.Services.AddSingleton<MediaServerClientFactory>();
     b.Services.AddScheduledService<TimeAgoService>();
     b.Services.AddScheduledService<MediaConverterService>();
     b.Services.AddScheduledService<ArrSyncService>();

--- a/Muxarr.Web/Services/ArrSyncService.cs
+++ b/Muxarr.Web/Services/ArrSyncService.cs
@@ -64,7 +64,7 @@ public class ArrSyncService(
                         Title = x.Title
                     }), conn.Id, token);
                 }
-                else
+                else if (conn.Type == IntegrationType.Sonarr)
                 {
                     var result = await arrApi.SyncSeries(conn);
                     if (result.Count > 0)
@@ -81,6 +81,10 @@ public class ArrSyncService(
                         Path = x.Path,
                         Title = x.Title
                     }), conn.Id, token);
+                }
+                else
+                {
+                    continue;
                 }
             }
             catch (Exception ex) when (ex is not OperationCanceledException)

--- a/Muxarr.Web/Services/MediaConverterService.cs
+++ b/Muxarr.Web/Services/MediaConverterService.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Muxarr.Core.Api;
 using Muxarr.Core.Config;
 using Muxarr.Core.Extensions;
 using Muxarr.Core.FFmpeg;
@@ -15,6 +16,7 @@ namespace Muxarr.Web.Services;
 public class MediaConverterService(
     IServiceScopeFactory serviceScopeFactory,
     MediaScannerService scanner,
+    MediaServerClientFactory mediaServerClientFactory,
     ILogger<MediaConverterService> logger)
     : ConfigurableServiceBase<ProcessingConfig>(serviceScopeFactory, logger)
 {
@@ -696,6 +698,12 @@ public class MediaConverterService(
 
     private async Task RunPostProcessing(MediaConversion conversion)
     {
+        await RunCustomPostProcessing(conversion);
+        await RunMediaServerRefresh(conversion);
+    }
+
+    private async Task RunCustomPostProcessing(MediaConversion conversion)
+    {
         if (!Config.PostProcessingEnabled || string.IsNullOrWhiteSpace(Config.PostProcessingCommand))
         {
             return;
@@ -732,6 +740,17 @@ public class MediaConverterService(
         {
             conversion.Log($"Post-processing failed: {e.Message}", logger, true);
         }
+    }
+
+    private async Task RunMediaServerRefresh(MediaConversion conversion)
+    {
+        if (!Config.MediaServerRefreshEnabled)
+        {
+            return;
+        }
+
+        conversion.Log("Refreshing media servers..", logger);
+        await mediaServerClientFactory.RefreshAll(conversion.MediaFile!.Path);
     }
 }
 

--- a/Muxarr.Web/Services/MediaConverterService.cs
+++ b/Muxarr.Web/Services/MediaConverterService.cs
@@ -750,7 +750,15 @@ public class MediaConverterService(
         }
 
         conversion.Log("Refreshing media servers..", logger);
-        await mediaServerClientFactory.RefreshAll(conversion.MediaFile!.Path);
+
+        try
+        {
+            await mediaServerClientFactory.RefreshAll(conversion.MediaFile!.Path);
+        }
+        catch (Exception e)
+        {
+            conversion.Log($"Media server refresh failed: {e.Message}", logger, true);
+        }
     }
 }
 

--- a/Muxarr.Web/Services/MediaServerClientFactory.cs
+++ b/Muxarr.Web/Services/MediaServerClientFactory.cs
@@ -1,0 +1,67 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Muxarr.Core.Api;
+using Muxarr.Data;
+using Muxarr.Data.Entities;
+
+namespace Muxarr.Web.Services;
+
+public class MediaServerClientFactory(
+    JellyfinEmbyApiClient jellyfinEmbyClient,
+    PlexApiClient plexClient,
+    IServiceScopeFactory serviceScopeFactory,
+    ILogger<MediaServerClientFactory> logger)
+{
+    public IMediaServerClient? GetClient(IntegrationType type) => type switch
+    {
+        IntegrationType.Jellyfin => jellyfinEmbyClient,
+        IntegrationType.Emby => jellyfinEmbyClient,
+        IntegrationType.Plex => plexClient,
+        _ => null
+    };
+
+    public async Task RefreshAll(string mediaPath)
+    {
+        using var scope = serviceScopeFactory.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var services = await context.Integrations
+            .AsNoTracking()
+            .Where(x => (x.Type == IntegrationType.Jellyfin || x.Type == IntegrationType.Emby || x.Type == IntegrationType.Plex) &&
+                        !string.IsNullOrWhiteSpace(x.Url) &&
+                        !string.IsNullOrWhiteSpace(x.ApiKey))
+            .OrderBy(x => x.Id)
+            .ToListAsync();
+
+        if (services.Count == 0)
+        {
+            logger.LogInformation("Media server refresh: no configured media server connections found");
+            return;
+        }
+
+        foreach (var service in services)
+        {
+            var client = GetClient(service.Type);
+            if (client == null)
+            {
+                logger.LogWarning("No API client available for {Type} ({Name})", service.Type, service.Name);
+                continue;
+            }
+
+            var result = await client.UpdateMedia(service, mediaPath);
+            if (result.Success)
+            {
+                logger.LogInformation(
+                    "{Type} accepted {Mode} for {Name} and path {Path}",
+                    service.Type,
+                    result.Mode,
+                    service.Name,
+                    mediaPath);
+            }
+            else
+            {
+                logger.LogWarning("Failed to update {Type} for {Name}", service.Type, service.Name);
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -124,6 +124,12 @@ docker run -d \
 4. Create a profile with your media directories and language rules
 5. Scan your library, preview the changes, and queue files for processing
 
+### Media Server Refresh
+
+Muxarr can notify Jellyfin, Emby, and Plex after a successful conversion so your library can pick up the updated file.
+
+For the most reliable refresh behavior, mount your media with the same absolute paths in both containers, for example `/mnt/media:/media` in Muxarr and your media server. Path mapping between different container paths is not supported.
+
 ### API
 
 Muxarr exposes a stats API at `/api/stats` (authenticated via `X-Api-Key` header). Works with [Homepage](https://gethomepage.dev/widgets/services/customapi/) and other dashboards. See Settings > API for examples.


### PR DESCRIPTION
## Media Server Library Refresh After Conversion
Post-processing can be quite technical, so this provides a simple solution to sync converted files with the media server efficiently only updating files that have changed.

## Features
- Updates only the converted file on the selected media server
- Supports media servers: Plex, Jellyfin, and Emby

## Preview
<img width="1662" height="741" alt="image" src="https://github.com/user-attachments/assets/60284dc5-0797-4322-a677-5379cc81a429" />
<img width="3334" height="287" alt="image" src="https://github.com/user-attachments/assets/0a5f6bb8-f6bf-49cf-9d96-71d44514e562" />
<img width="1385" height="46" alt="image" src="https://github.com/user-attachments/assets/8407d7da-6b85-458a-9133-985af70be8c1" />
