### PR TITLE
Improve "Size Reduction" column

### DIFF
--- a/Muxarr.Web/Components/Pages/Conversions/Index.razor
+++ b/Muxarr.Web/Components/Pages/Conversions/Index.razor
@@ -209,6 +209,10 @@
                             @if (conversion.State == ConversionState.Completed)
                             {
                                 <span>@conversion.GetSizeChangePercentage()</span>
+                                @if (conversion.SizeDifference > 0)
+                                {
+                                    <span class="text-nowrap">(@conversion.SizeDifference.DisplayFileSize())</span>
+                                }
                             }
                         </td>
                         <td>
@@ -416,4 +420,5 @@
         MediaConverter.QueueStateChanged -= OnQueueStateChanged;
         base.Dispose();
     }
+
 }


### PR DESCRIPTION
To me it was confusing at first why the % didn't match the order when sorting by "Size Reduction" until i realized it was ordered by actual filesize and not %.

Another option could be to add a second column so you can order by % or size.

Or change the sorting to go by % 😆 