### PR TITLE
Proposal: Truncate to shortest track (if video)

### DIFF
--- a/Muxarr.Core/FFmpeg/FFmpeg.cs
+++ b/Muxarr.Core/FFmpeg/FFmpeg.cs
@@ -29,7 +29,7 @@ public static class FFmpeg
     {
         var result = await ProcessExecutor.ExecuteProcessAsync(
             FfprobeExecutable,
-            $"-v error -print_format json -show_streams -show_format \"{file}\"",
+            $"-v error -print_format json -show_streams -show_format -show_entries stream \"{file}\"",
             TimeSpan.FromSeconds(30));
 
         var json = new ProcessJsonResult<FFprobeResult>(result);

--- a/Muxarr.Core/FFmpeg/FFprobeInfo.cs
+++ b/Muxarr.Core/FFmpeg/FFprobeInfo.cs
@@ -39,6 +39,9 @@ public class FFprobeStream
     // String to tolerate ffprobe's "N/A" for non-video streams.
     [JsonPropertyName("bits_per_raw_sample")]
     public string? BitsPerRawSample { get; set; }
+    
+    [JsonPropertyName("duration")]
+    public double? Duration { get; set; }
 
     [JsonPropertyName("disposition")]
     public FFprobeDisposition? Disposition { get; set; }
@@ -90,5 +93,5 @@ public class FFprobeFormat
     public string? FormatName { get; set; }
 
     [JsonPropertyName("duration")]
-    public string? Duration { get; set; }
+    public double? Duration { get; set; }
 }

--- a/Muxarr.Core/FFmpeg/FFprobeInfo.cs
+++ b/Muxarr.Core/FFmpeg/FFprobeInfo.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using Muxarr.Core.Json;
 
 namespace Muxarr.Core.FFmpeg;
 
@@ -40,7 +41,7 @@ public class FFprobeStream
     [JsonPropertyName("bits_per_raw_sample")]
     public string? BitsPerRawSample { get; set; }
     
-    [JsonPropertyName("duration")]
+    [JsonPropertyName("duration"), JsonConverter(typeof(JsonStringToDoubleConverter))]
     public double? Duration { get; set; }
 
     [JsonPropertyName("disposition")]
@@ -92,6 +93,6 @@ public class FFprobeFormat
     [JsonPropertyName("format_name")]
     public string? FormatName { get; set; }
 
-    [JsonPropertyName("duration")]
+    [JsonPropertyName("duration"), JsonConverter(typeof(JsonStringToDoubleConverter))]
     public double? Duration { get; set; }
 }

--- a/Muxarr.Core/Json/JsonStringToDoubleConverter.cs
+++ b/Muxarr.Core/Json/JsonStringToDoubleConverter.cs
@@ -1,0 +1,16 @@
+﻿using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Muxarr.Core.Json;
+
+public class JsonStringToDoubleConverter : JsonConverter<double?>
+{
+    public override double? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        => double.TryParse(reader.GetString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var value)
+            ? value
+            : null; 
+
+    public override void Write(Utf8JsonWriter writer, double? value, JsonSerializerOptions options) =>
+        throw new NotImplementedException();
+}

--- a/Muxarr.Core/Muxarr.Core.csproj
+++ b/Muxarr.Core/Muxarr.Core.csproj
@@ -18,8 +18,4 @@
       <EmbeddedResource Include="Language\iso_custom.json" />
     </ItemGroup>
 
-    <ItemGroup>
-      <Folder Include="Json\" />
-    </ItemGroup>
-
 </Project>

--- a/Muxarr.Core/Muxarr.Core.csproj
+++ b/Muxarr.Core/Muxarr.Core.csproj
@@ -18,4 +18,8 @@
       <EmbeddedResource Include="Language\iso_custom.json" />
     </ItemGroup>
 
+    <ItemGroup>
+      <Folder Include="Json\" />
+    </ItemGroup>
+
 </Project>

--- a/Muxarr.Data/Entities/IMediaTrack.cs
+++ b/Muxarr.Data/Entities/IMediaTrack.cs
@@ -15,4 +15,5 @@ public interface IMediaTrack
     bool IsDefault { get; }
     bool IsForced { get; }
     bool IsOriginal { get; }
+    double? Duration { get; }
 }

--- a/Muxarr.Data/Entities/MediaFile.cs
+++ b/Muxarr.Data/Entities/MediaFile.cs
@@ -14,6 +14,8 @@ public class MediaFile : AuditableEntity
     public string? ProbeOutput { get; set; }
     public bool HasScanWarning { get; set; }
     public bool HasFaststart { get; set; }
+    
+    public bool HasInvalidDuration { get; set; }
     public ICollection<MediaTrack> Tracks { get; set; } = new List<MediaTrack>();
     public int TrackCount { get; set; }
     public bool HasRedundantTracks { get; set; }
@@ -46,7 +48,8 @@ public class MediaTrack : IMediaTrack
     public string LanguageCode { get; set; } = string.Empty;
     public string LanguageName { get; set; } = string.Empty;
     public string? TrackName { get; set; } = string.Empty;
-
+    
+    public double? Duration { get; set; }
     public MediaFile? MediaFile { get; set; }
 }
 

--- a/Muxarr.Data/Entities/Profile.cs
+++ b/Muxarr.Data/Entities/Profile.cs
@@ -79,6 +79,7 @@ namespace Muxarr.Data.Entities
         public List<string> Directories { get; set; } = new();
         public bool ClearVideoTrackNames { get; set; }
         public bool SkipHardlinkedFiles { get; set; }
+        public bool TruncateToShortest { get; set; }
         public TrackSettings AudioSettings { get; set; } = new();
         public TrackSettings SubtitleSettings { get; set; } = new();
         public ICollection<MediaFile> MediaFiles { get; set; } = new List<MediaFile>();

--- a/Muxarr.Data/Entities/TrackSnapshot.cs
+++ b/Muxarr.Data/Entities/TrackSnapshot.cs
@@ -20,6 +20,8 @@ public class TrackSnapshot : IMediaTrack
     public string LanguageCode { get; set; } = string.Empty;
     public string LanguageName { get; set; } = string.Empty;
     public string? TrackName { get; set; } = string.Empty;
+    
+    public double? Duration { get; set; }
 
     [JsonPropertyName("Id")]
     public int TrackNumber { get; set; }

--- a/Muxarr.Data/Extensions/MediaFileExtensions.cs
+++ b/Muxarr.Data/Extensions/MediaFileExtensions.cs
@@ -89,7 +89,8 @@ public static class MediaFileExtensions
             };
 
             if (track.Type != MediaTrackType.Video
-                && (track.LanguageName == IsoLanguage.UnknownName || track.LanguageName == IsoLanguage.UndeterminedName))
+                && (track.LanguageName == IsoLanguage.UnknownName ||
+                    track.LanguageName == IsoLanguage.UndeterminedName))
             {
                 var parsed = IsoLanguage.Find(x.Properties.TrackName, true);
                 if (parsed != IsoLanguage.Unknown)
@@ -173,7 +174,8 @@ public static class MediaFileExtensions
                 AudioChannels = stream.Channels,
                 IsDefault = disposition.Default == 1,
                 IsForced = disposition.Forced == 1 || TrackNameFlags.ContainsForced(trackName),
-                IsHearingImpaired = disposition.HearingImpaired == 1 || TrackNameFlags.ContainsHearingImpaired(trackName),
+                IsHearingImpaired =
+                    disposition.HearingImpaired == 1 || TrackNameFlags.ContainsHearingImpaired(trackName),
                 // flag_text_descriptions in Matroska is exposed by ffprobe
                 // as disposition.descriptions; merge it in so the parity
                 // against mkvmerge's IsVisualImpaired stays tight.
@@ -182,22 +184,20 @@ public static class MediaFileExtensions
                                    || TrackNameFlags.ContainsVisualImpaired(trackName),
                 IsCommentary = disposition.Comment == 1 || TrackNameFlags.ContainsCommentary(trackName),
                 IsOriginal = disposition.Original == 1,
-                Duration = type switch
-                {
-                    MediaTrackType.Video or MediaTrackType.Audio => stream.Duration ?? probe.Format?.Duration,
-                    MediaTrackType.Subtitles => stream.Duration,
-                    _ => null
-                }
+                Duration = stream.Duration ?? ParseTagDuration(stream.Tags) ?? probe.Format?.Duration
             };
 
-            // static double? ParseTagDuration(Dictionary<string, string>? tags)
-            // {
-            //     if (tags is null || !tags.ContainsKey("DURATION"))
-            //         return null;
-            // }
+            static double? ParseTagDuration(Dictionary<string, string>? tags)
+            {
+                if (tags is null || !tags.TryGetValue("DURATION", out var duration))
+                    return null;
+
+                return TimeSpan.Parse(duration).TotalSeconds;
+            }
 
             if (track.Type != MediaTrackType.Video
-                && (track.LanguageName == IsoLanguage.UnknownName || track.LanguageName == IsoLanguage.UndeterminedName))
+                && (track.LanguageName == IsoLanguage.UnknownName ||
+                    track.LanguageName == IsoLanguage.UndeterminedName))
             {
                 var parsed = IsoLanguage.Find(trackName, true);
                 if (parsed != IsoLanguage.Unknown)
@@ -217,12 +217,13 @@ public static class MediaFileExtensions
         {
             file.Resolution = $"{video.Width}x{video.Height}";
         }
+
         file.VideoBitDepth = int.TryParse(video?.BitsPerRawSample, out var depth) ? depth : 0;
 
         // TODO: stewie - use json converter for all duration fields and convert to ms
         // if (double.TryParse(probe.Format?.Duration, NumberStyles.Any, CultureInfo.InvariantCulture, out var durationSec))
         // {
-            file.DurationMs = (long)(probe.Format?.Duration ?? 0 * 1000);
+        file.DurationMs = (long)((probe.Format?.Duration ?? 0) * 1000);
         // }
 
         return probeResult;
@@ -245,6 +246,7 @@ public static class MediaFileExtensions
         {
             return "Matroska";
         }
+
         if (lower.Contains("mp4") || lower.Contains("mov") || lower.Contains("m4a") || lower.Contains("3gp"))
         {
             return "MP4/QuickTime";
@@ -276,14 +278,17 @@ public static class MediaFileExtensions
         {
             return null;
         }
+
         if (tags.TryGetValue("name", out var name) && !string.IsNullOrEmpty(name))
         {
             return name;
         }
+
         if (tags.TryGetValue("title", out var title) && !string.IsNullOrEmpty(title))
         {
             return title;
         }
+
         return null;
     }
 
@@ -305,7 +310,8 @@ public static class MediaFileExtensions
         return result;
     }
 
-    public static List<T> GetAllowedTracks<T>(this List<T> tracks, TrackSettings s, string? originalLanguage) where T : IMediaTrack
+    public static List<T> GetAllowedTracks<T>(this List<T> tracks, TrackSettings s, string? originalLanguage)
+        where T : IMediaTrack
     {
         if (tracks.Count == 0)
         {
@@ -321,8 +327,8 @@ public static class MediaFileExtensions
             // Their explicit allow should take precedence over the original-language assumption.
             var undeterminedExplicitlyAllowed = s.AllowedLanguages.Any(x => x.Name == IsoLanguage.UndeterminedName);
             var assumeUndetermined = !undeterminedExplicitlyAllowed
-                                      && tracks.Count == 1
-                                      && tracks[0].ShouldResolveUndetermined(s, 1, originalLanguage);
+                                     && tracks.Count == 1
+                                     && tracks[0].ShouldResolveUndetermined(s, 1, originalLanguage);
 
             var tracksByLanguage = tracks.GroupBy(t =>
                 t.LanguageName == IsoLanguage.UnknownName ? (originalLanguage ?? IsoLanguage.UnknownName)
@@ -462,6 +468,7 @@ public static class MediaFileExtensions
                 best = Math.Min(best, i);
             }
         }
+
         return best;
     }
 
@@ -571,6 +578,7 @@ public static class MediaFileExtensions
                 return true;
             }
         }
+
         return false;
     }
 
@@ -602,6 +610,15 @@ public static class MediaFileExtensions
     public static void ApplyProfileMutations(this List<TrackSnapshot> snapshots, Profile profile,
         int totalAudioTracks, int totalSubtitleTracks, string? originalLanguage, bool standardizeNames = true)
     {
+        double? truncateTarget = null;
+        if (profile.TruncateToShortest)
+        {
+            if (snapshots.OrderBy(t => t.Duration).First() is { Type: MediaTrackType.Video } shortest)
+            {
+                truncateTarget = shortest.Duration;
+            }
+        }
+
         foreach (var snapshot in snapshots)
         {
             if (snapshot.Type == MediaTrackType.Video)
@@ -619,7 +636,8 @@ public static class MediaFileExtensions
                 : profile.SubtitleSettings;
 
             var totalTracksOfType = snapshot.Type == MediaTrackType.Audio ? totalAudioTracks : totalSubtitleTracks;
-            snapshot.ApplyTrackMutations(settings, totalTracksOfType, originalLanguage, standardizeNames);
+            snapshot.ApplyTrackMutations(settings, totalTracksOfType, originalLanguage, standardizeNames,
+                truncateTarget);
         }
 
         ReassignPreviewDefaultFlags(snapshots, profile.AudioSettings, MediaTrackType.Audio, originalLanguage);
@@ -633,7 +651,7 @@ public static class MediaFileExtensions
     /// undetermined language resolution, and optionally track name standardization.
     /// </summary>
     public static void ApplyTrackMutations(this TrackSnapshot track, TrackSettings? settings,
-        int totalTracksOfType, string? originalLanguage, bool standardizeNames = true)
+        int totalTracksOfType, string? originalLanguage, bool standardizeNames = true, double? truncateTarget = null)
     {
         track.CorrectFlagsFromTrackName();
 
@@ -648,6 +666,11 @@ public static class MediaFileExtensions
         {
             var template = settings.ResolveTemplate(track);
             track.TrackName = track.ApplyTrackNameTemplate(template);
+        }
+
+        if (truncateTarget.HasValue)
+        {
+            track.Duration = truncateTarget;
         }
     }
 
@@ -704,11 +727,31 @@ public static class MediaFileExtensions
     private static string GetFlagLabels(this IMediaTrack track)
     {
         var labels = new List<string>();
-        if (track.IsHearingImpaired) { labels.Add("SDH"); }
-        if (track.IsForced) { labels.Add("Forced"); }
-        if (track.IsCommentary) { labels.Add("Commentary"); }
-        if (track.IsVisualImpaired) { labels.Add("AD"); }
-        if (track.IsOriginal) { labels.Add("Original"); }
+        if (track.IsHearingImpaired)
+        {
+            labels.Add("SDH");
+        }
+
+        if (track.IsForced)
+        {
+            labels.Add("Forced");
+        }
+
+        if (track.IsCommentary)
+        {
+            labels.Add("Commentary");
+        }
+
+        if (track.IsVisualImpaired)
+        {
+            labels.Add("AD");
+        }
+
+        if (track.IsOriginal)
+        {
+            labels.Add("Original");
+        }
+
         return string.Join(", ", labels);
     }
 
@@ -741,7 +784,8 @@ public static class MediaFileExtensions
             IsVisualImpaired = track.IsVisualImpaired,
             IsDefault = track.IsDefault,
             IsForced = track.IsForced,
-            IsOriginal = track.IsOriginal
+            IsOriginal = track.IsOriginal,
+            Duration = track.Duration
         };
     }
 
@@ -800,7 +844,9 @@ public static class MediaFileExtensions
             }
             else
             {
-                var trackSettings = track.Type == MediaTrackType.Audio ? profile?.AudioSettings : profile?.SubtitleSettings;
+                var trackSettings = track.Type == MediaTrackType.Audio
+                    ? profile?.AudioSettings
+                    : profile?.SubtitleSettings;
                 if (isCustomConversion || trackSettings is { StandardizeTrackNames: true })
                 {
                     output.Name = track.TrackName;
@@ -879,15 +925,17 @@ public static class MediaFileExtensions
         if (original == null)
         {
             return output.Name != null || output.LanguageCode != null || output.IsDefault != null
-                || output.IsForced != null || output.IsHearingImpaired != null || output.IsCommentary != null;
+                   || output.IsForced != null || output.IsHearingImpaired != null || output.IsCommentary != null;
         }
 
-        return (output.Name != null && !string.Equals(output.Name ?? "", original.TrackName ?? "", StringComparison.Ordinal))
-            || (output.LanguageCode != null && !string.Equals(output.LanguageCode, original.LanguageCode, StringComparison.Ordinal))
-            || (output.IsDefault != null && output.IsDefault != original.IsDefault)
-            || (output.IsForced != null && output.IsForced != original.IsForced)
-            || (output.IsHearingImpaired != null && output.IsHearingImpaired != original.IsHearingImpaired)
-            || (output.IsCommentary != null && output.IsCommentary != original.IsCommentary);
+        return (output.Name != null &&
+                !string.Equals(output.Name ?? "", original.TrackName ?? "", StringComparison.Ordinal))
+               || (output.LanguageCode != null &&
+                   !string.Equals(output.LanguageCode, original.LanguageCode, StringComparison.Ordinal))
+               || (output.IsDefault != null && output.IsDefault != original.IsDefault)
+               || (output.IsForced != null && output.IsForced != original.IsForced)
+               || (output.IsHearingImpaired != null && output.IsHearingImpaired != original.IsHearingImpaired)
+               || (output.IsCommentary != null && output.IsCommentary != original.IsCommentary);
     }
 
     // Helpers

--- a/Muxarr.Data/Extensions/MediaFileExtensions.cs
+++ b/Muxarr.Data/Extensions/MediaFileExtensions.cs
@@ -84,7 +84,8 @@ public static class MediaFileExtensions
                 AudioChannels = x.Properties.AudioChannels,
                 Codec = CodecExtensions.ParseCodec(x.Codec),
                 TrackName = x.Properties.TrackName,
-                TrackNumber = x.Id
+                TrackNumber = x.Id,
+                Duration = 0
             };
 
             if (track.Type != MediaTrackType.Video
@@ -180,8 +181,20 @@ public static class MediaFileExtensions
                                    || disposition.Descriptions == 1
                                    || TrackNameFlags.ContainsVisualImpaired(trackName),
                 IsCommentary = disposition.Comment == 1 || TrackNameFlags.ContainsCommentary(trackName),
-                IsOriginal = disposition.Original == 1
+                IsOriginal = disposition.Original == 1,
+                Duration = type switch
+                {
+                    MediaTrackType.Video or MediaTrackType.Audio => stream.Duration ?? probe.Format?.Duration,
+                    MediaTrackType.Subtitles => stream.Duration,
+                    _ => null
+                }
             };
+
+            // static double? ParseTagDuration(Dictionary<string, string>? tags)
+            // {
+            //     if (tags is null || !tags.ContainsKey("DURATION"))
+            //         return null;
+            // }
 
             if (track.Type != MediaTrackType.Video
                 && (track.LanguageName == IsoLanguage.UnknownName || track.LanguageName == IsoLanguage.UndeterminedName))
@@ -206,10 +219,11 @@ public static class MediaFileExtensions
         }
         file.VideoBitDepth = int.TryParse(video?.BitsPerRawSample, out var depth) ? depth : 0;
 
-        if (double.TryParse(probe.Format?.Duration, NumberStyles.Any, CultureInfo.InvariantCulture, out var durationSec))
-        {
-            file.DurationMs = (long)(durationSec * 1000);
-        }
+        // TODO: stewie - use json converter for all duration fields and convert to ms
+        // if (double.TryParse(probe.Format?.Duration, NumberStyles.Any, CultureInfo.InvariantCulture, out var durationSec))
+        // {
+            file.DurationMs = (long)(probe.Format?.Duration ?? 0 * 1000);
+        // }
 
         return probeResult;
     }

--- a/Muxarr.Data/Extensions/MediaFileExtensions.cs
+++ b/Muxarr.Data/Extensions/MediaFileExtensions.cs
@@ -613,7 +613,8 @@ public static class MediaFileExtensions
         double? truncateTarget = null;
         if (profile.TruncateToShortest)
         {
-            if (snapshots.OrderBy(t => t.Duration).First() is { Type: MediaTrackType.Video } shortest)
+            // Ensure video track is first when video/audio tracks are the same length
+            if (snapshots.OrderBy(t => t.Duration).ThenBy(t => t.Type is MediaTrackType.Video ? 0 : 1).First() is { Type: MediaTrackType.Video } shortest)
             {
                 truncateTarget = shortest.Duration;
             }

--- a/Muxarr.Data/Extensions/MediaFileExtensions.cs
+++ b/Muxarr.Data/Extensions/MediaFileExtensions.cs
@@ -184,7 +184,7 @@ public static class MediaFileExtensions
                                    || TrackNameFlags.ContainsVisualImpaired(trackName),
                 IsCommentary = disposition.Comment == 1 || TrackNameFlags.ContainsCommentary(trackName),
                 IsOriginal = disposition.Original == 1,
-                Duration = stream.Duration ?? ParseTagDuration(stream.Tags) ?? probe.Format?.Duration
+                Duration = stream.Duration ?? ParseTagDuration(stream.Tags) ?? stream.Duration ?? probe.Format?.Duration
             };
 
             static double? ParseTagDuration(Dictionary<string, string>? tags)

--- a/Muxarr.Data/Migrations/20260410150036_AddTrackDuration.Designer.cs
+++ b/Muxarr.Data/Migrations/20260410150036_AddTrackDuration.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Muxarr.Data;
 
@@ -10,9 +11,11 @@ using Muxarr.Data;
 namespace Muxarr.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260410150036_AddTrackDuration")]
+    partial class AddTrackDuration
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.5");

--- a/Muxarr.Data/Migrations/20260410150036_AddTrackDuration.cs
+++ b/Muxarr.Data/Migrations/20260410150036_AddTrackDuration.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Muxarr.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTrackDuration : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<double>(
+                name: "Duration",
+                table: "MediaTrack",
+                type: "REAL",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "HasInvalidDuration",
+                table: "MediaFile",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Duration",
+                table: "MediaTrack");
+
+            migrationBuilder.DropColumn(
+                name: "HasInvalidDuration",
+                table: "MediaFile");
+        }
+    }
+}

--- a/Muxarr.Data/Migrations/20260410153759_TruncateProp.Designer.cs
+++ b/Muxarr.Data/Migrations/20260410153759_TruncateProp.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Muxarr.Data;
 
@@ -10,9 +11,11 @@ using Muxarr.Data;
 namespace Muxarr.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260410153759_TruncateProp")]
+    partial class TruncateProp
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.5");

--- a/Muxarr.Data/Migrations/20260410153759_TruncateProp.cs
+++ b/Muxarr.Data/Migrations/20260410153759_TruncateProp.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Muxarr.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class TruncateProp : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "TruncateToShortest",
+                table: "Profile",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "TruncateToShortest",
+                table: "Profile");
+        }
+    }
+}

--- a/Muxarr.Web/Components/Pages/Library/MediaTrackDetail.razor
+++ b/Muxarr.Web/Components/Pages/Library/MediaTrackDetail.razor
@@ -27,6 +27,8 @@
             </ToolTip>
         }
     </td>
+    
+    <td>@Track.Duration</td>
     <td><code>@Track.Codec.FormatCodec()</code></td>
     <td>
         @* Track name changes *@

--- a/Muxarr.Web/Components/Pages/Library/MediaTrackDetail.razor
+++ b/Muxarr.Web/Components/Pages/Library/MediaTrackDetail.razor
@@ -28,7 +28,7 @@
         }
     </td>
     
-    <td>@Track.Duration</td>
+    <td>@(Preview?.Duration ?? Track.Duration)</td>
     <td><code>@Track.Codec.FormatCodec()</code></td>
     <td>
         @* Track name changes *@

--- a/Muxarr.Web/Components/Pages/Library/MediaTrackDetailTable.razor
+++ b/Muxarr.Web/Components/Pages/Library/MediaTrackDetailTable.razor
@@ -3,6 +3,7 @@
     <tr>
         <th style="width: 35px;">#</th>
         <th>Language</th>
+        <th>Duration</th>
         <th>Format</th>
         <th>Details</th>
     </tr>
@@ -22,6 +23,7 @@
             <td>
                 <MediaTrackLabel Track="track" ShowAllFlags="true"/>
             </td>
+            <td>@track.Duration</td>
             <td><code>@track.Codec.FormatCodec()</code></td>
             <td><i class="bi bi-x-circle-fill text-danger"></i> will be removed</td>
         </tr>

--- a/Muxarr.Web/Components/Pages/Settings/ProfileEdit.razor
+++ b/Muxarr.Web/Components/Pages/Settings/ProfileEdit.razor
@@ -71,6 +71,12 @@
                                 profile.</small>
                         </div>
                         <div class="mb-3 form-check form-switch">
+                            <InputCheckbox id="truncateShortest" class="form-check-input"
+                                           @bind-Value="_profile.TruncateToShortest"/>
+                            <label class="form-check-label" for="truncateShortest">Truncate to shortest track</label>
+                            <small class="form-text text-muted d-block">whatever</small>
+                        </div>
+                        <div class="mb-3 form-check form-switch">
                             <InputCheckbox id="skipHardlinked" class="form-check-input"
                                            @bind-Value="_profile.SkipHardlinkedFiles"/>
                             <label class="form-check-label" for="skipHardlinked">Skip hardlinked files</label>
@@ -183,6 +189,7 @@
                 existing.SkipHardlinkedFiles = _profile.SkipHardlinkedFiles;
                 existing.AudioSettings = _profile.AudioSettings;
                 existing.SubtitleSettings = _profile.SubtitleSettings;
+                existing.TruncateToShortest = _profile.TruncateToShortest;
                 context.Update(existing);
             }
 

--- a/Muxarr.Web/Services/MediaConverterService.cs
+++ b/Muxarr.Web/Services/MediaConverterService.cs
@@ -346,13 +346,13 @@ public class MediaConverterService(
             MkvMerge.KillExistingProcesses();
             FFmpeg.KillExistingProcesses();
             conversion.LogError("Conversion was cancelled.", logger);
-            await context.SaveChangesAsync();
+            await context.SaveChangesAsync(token);
         }
         catch (Exception e)
         {
             conversion.LogError(
                 $"Something bad happened while processing {conversion.MediaFile.Path}. Error: {e.Message}", logger);
-            await context.SaveChangesAsync();
+            await context.SaveChangesAsync(token);
         }
         finally
         {
@@ -371,7 +371,7 @@ public class MediaConverterService(
 
             try
             {
-                await context.SaveChangesAsync();
+                await context.SaveChangesAsync(token);
             }
             catch
             {


### PR DESCRIPTION
This is just a rough implementation (without the actual truncating atm) as a proposal

- How should the change be shown in the preview/conversion table? (Obviously need to properly format a display value 😆 
- Probably also want to show a warning kinda tag somewhere on the detail page indicating that the different lengths will be an issue
- Could also check if the difference is relevant for the threshold
- Write tests (how do you create those dummy mkv files for testing?)


Setting in profiles
<img width="510" height="278" alt="image" src="https://github.com/user-attachments/assets/7571a75a-9a3f-4201-ab8c-f6f29bb5b40a" />


Library view
<img width="415" height="261" alt="image" src="https://github.com/user-attachments/assets/5e4beb00-c712-4dc1-baae-081abd36b015" />

<img width="405" height="332" alt="image" src="https://github.com/user-attachments/assets/f119e7f0-11ae-4b44-8650-38bd34cb67de" />

