### PR TITLE
Add external subtitle muxing (detect & mux sibling .srt/.ass into MKV)

### DIFF
--- a/Muxarr.Core/MkvToolNix/MkvMerge.cs
+++ b/Muxarr.Core/MkvToolNix/MkvMerge.cs
@@ -124,6 +124,12 @@ public static class MkvMerge
         foreach (var path in externalPaths)
         {
             var external = tracks.Where(t => t.SourcePath == path).ToList();
+            if (external.Count > 1)
+            {
+                throw new ArgumentException(
+                    $"External input '{path}' maps to {external.Count} tracks; only single-track external " +
+                    "subtitle files are supported.", nameof(delta));
+            }
             command += BuildTrackFlags(external, _ => 0);
             command += $" \"{path}\"";
         }

--- a/Muxarr.Core/MkvToolNix/MkvMerge.cs
+++ b/Muxarr.Core/MkvToolNix/MkvMerge.cs
@@ -44,81 +44,7 @@ public static class MkvMerge
     public static async Task<ProcessResult> Remux(string input, string output, ConversionPlan delta,
         Action<string, int>? onProgress = null, TimeSpan? timeout = null)
     {
-        var tracks = delta.Tracks;
-        if (tracks.Count == 0)
-        {
-            throw new ArgumentException("At least one track is required.", nameof(delta));
-        }
-
-        var audioTracks = tracks.Where(t => t.Type == MediaTrackType.Audio).ToList();
-        var subtitleTracks = tracks.Where(t => t.Type == MediaTrackType.Subtitles).ToList();
-
-        var command = $"-o \"{output}\"";
-
-        command += audioTracks.Count > 0
-            ? $" --audio-tracks {string.Join(",", audioTracks.Select(t => t.Index))}"
-            : " --no-audio";
-
-        command += subtitleTracks.Count > 0
-            ? $" --subtitle-tracks {string.Join(",", subtitleTracks.Select(t => t.Index))}"
-            : " --no-subtitles";
-
-        if (delta.HasChapters == false)
-        {
-            command += " --no-chapters";
-        }
-
-        if (delta.HasAttachments == false)
-        {
-            command += " --no-attachments";
-        }
-
-        foreach (var track in tracks)
-        {
-            if (track.Name != null)
-            {
-                command += $" --track-name {track.Index}:{MkvToolNixHelper.EscapeValue(track.Name)}";
-            }
-
-            if (track.LanguageCode != null)
-            {
-                command += $" --language {track.Index}:{track.LanguageCode}";
-            }
-
-            if (track.IsDefault != null)
-            {
-                command += $" --default-track-flag {track.Index}:{(track.IsDefault.Value ? "1" : "0")}";
-            }
-
-            if (track.IsForced != null)
-            {
-                command += $" --forced-display-flag {track.Index}:{(track.IsForced.Value ? "1" : "0")}";
-            }
-
-            if (track.IsHearingImpaired != null)
-            {
-                command +=
-                    $" --hearing-impaired-flag {track.Index}:{(track.IsHearingImpaired.Value ? "1" : "0")}";
-            }
-
-            if (track.IsVisualImpaired != null)
-            {
-                command += $" --visual-impaired-flag {track.Index}:{(track.IsVisualImpaired.Value ? "1" : "0")}";
-            }
-
-            if (track.IsCommentary != null)
-            {
-                command += $" --commentary-flag {track.Index}:{(track.IsCommentary.Value ? "1" : "0")}";
-            }
-
-            if (track.IsOriginal != null)
-            {
-                command += $" --original-flag {track.Index}:{(track.IsOriginal.Value ? "1" : "0")}";
-            }
-        }
-
-        command += $" \"{input}\"";
-        command += $" --track-order {string.Join(",", tracks.Select(t => $"0:{t.Index}"))}";
+        var command = BuildRemuxCommand(input, output, delta);
 
         var lastProgress = 0;
         return await ProcessExecutor.ExecuteProcessAsync(MkvMergeExecutable, command, timeout,
@@ -137,6 +63,131 @@ public static class MkvMerge
 
             onProgress?.Invoke(line, lastProgress);
         }
+    }
+
+    // Builds the mkvmerge argument string. Container is input file 0; each
+    // distinct TrackPlan.SourcePath becomes an additional input file. Per-track
+    // options use the track id *local to their input file* (external subtitle
+    // files contribute a single track, local id 0); only --track-order uses the
+    // global fileId:trackId pair.
+    // Public (not internal) so the test project can assert on the built string —
+    // Muxarr.Core has no InternalsVisibleTo for Muxarr.Tests.
+    public static string BuildRemuxCommand(string input, string output, ConversionPlan delta)
+    {
+        var tracks = delta.Tracks;
+        if (tracks.Count == 0)
+        {
+            throw new ArgumentException("At least one track is required.", nameof(delta));
+        }
+
+        var externalPaths = tracks
+            .Where(t => t.SourcePath != null)
+            .Select(t => t.SourcePath!)
+            .Distinct()
+            .ToList();
+
+        var fileIdByPath = new Dictionary<string, int>();
+        for (var i = 0; i < externalPaths.Count; i++)
+        {
+            fileIdByPath[externalPaths[i]] = i + 1;
+        }
+
+        var containerTracks = tracks.Where(t => t.SourcePath == null).ToList();
+        var containerAudio = containerTracks.Where(t => t.Type == MediaTrackType.Audio).ToList();
+        var containerSubs = containerTracks.Where(t => t.Type == MediaTrackType.Subtitles).ToList();
+
+        var command = $"-o \"{output}\"";
+
+        command += containerAudio.Count > 0
+            ? $" --audio-tracks {string.Join(",", containerAudio.Select(t => t.Index))}"
+            : " --no-audio";
+
+        command += containerSubs.Count > 0
+            ? $" --subtitle-tracks {string.Join(",", containerSubs.Select(t => t.Index))}"
+            : " --no-subtitles";
+
+        if (delta.HasChapters == false)
+        {
+            command += " --no-chapters";
+        }
+
+        if (delta.HasAttachments == false)
+        {
+            command += " --no-attachments";
+        }
+
+        // File 0: container track options use their real (container) index.
+        command += BuildTrackFlags(containerTracks, t => t.Index);
+        command += $" \"{input}\"";
+
+        // Additional inputs: each external subtitle file, local track id 0.
+        foreach (var path in externalPaths)
+        {
+            var external = tracks.Where(t => t.SourcePath == path).ToList();
+            command += BuildTrackFlags(external, _ => 0);
+            command += $" \"{path}\"";
+        }
+
+        var order = tracks.Select(t =>
+        {
+            var fileId = t.SourcePath == null ? 0 : fileIdByPath[t.SourcePath];
+            var trackId = t.SourcePath == null ? t.Index : 0;
+            return $"{fileId}:{trackId}";
+        });
+        command += $" --track-order {string.Join(",", order)}";
+
+        return command;
+    }
+
+    private static string BuildTrackFlags(IEnumerable<TrackPlan> tracks, Func<TrackPlan, int> localTrackId)
+    {
+        var sb = new System.Text.StringBuilder();
+        foreach (var track in tracks)
+        {
+            var id = localTrackId(track);
+
+            if (track.Name != null)
+            {
+                sb.Append($" --track-name {id}:{MkvToolNixHelper.EscapeValue(track.Name)}");
+            }
+
+            if (track.LanguageCode != null)
+            {
+                sb.Append($" --language {id}:{track.LanguageCode}");
+            }
+
+            if (track.IsDefault != null)
+            {
+                sb.Append($" --default-track-flag {id}:{(track.IsDefault.Value ? "1" : "0")}");
+            }
+
+            if (track.IsForced != null)
+            {
+                sb.Append($" --forced-display-flag {id}:{(track.IsForced.Value ? "1" : "0")}");
+            }
+
+            if (track.IsHearingImpaired != null)
+            {
+                sb.Append($" --hearing-impaired-flag {id}:{(track.IsHearingImpaired.Value ? "1" : "0")}");
+            }
+
+            if (track.IsVisualImpaired != null)
+            {
+                sb.Append($" --visual-impaired-flag {id}:{(track.IsVisualImpaired.Value ? "1" : "0")}");
+            }
+
+            if (track.IsCommentary != null)
+            {
+                sb.Append($" --commentary-flag {id}:{(track.IsCommentary.Value ? "1" : "0")}");
+            }
+
+            if (track.IsOriginal != null)
+            {
+                sb.Append($" --original-flag {id}:{(track.IsOriginal.Value ? "1" : "0")}");
+            }
+        }
+
+        return sb.ToString();
     }
 
     public static void KillExistingProcesses()

--- a/Muxarr.Core/Models/ConversionPlan.cs
+++ b/Muxarr.Core/Models/ConversionPlan.cs
@@ -28,6 +28,10 @@ public class TrackPlan : IMediaTrack
     public int Index { get; set; }
     public MediaTrackType Type { get; set; }
 
+    // Non-null = this planned track is sourced from an external file (mkvmerge
+    // additional input), not the container. Null = container track.
+    public string? SourcePath { get; set; }
+
     public string? Name { get; set; }
     public string? LanguageCode { get; set; }
     public bool? IsDefault { get; set; }

--- a/Muxarr.Core/Models/ExternalSubtitle.cs
+++ b/Muxarr.Core/Models/ExternalSubtitle.cs
@@ -1,0 +1,26 @@
+namespace Muxarr.Core.Models;
+
+// A subtitle file sitting next to a video that can be muxed into the container.
+// Implements IMediaTrack so it can flow through the same keep-list / priority /
+// limit logic as internal tracks. Persisted as JSON on MediaFile.ExternalSubtitles.
+public class ExternalSubtitle : IMediaTrack
+{
+    public string Path { get; set; } = string.Empty;
+    public string LanguageCode { get; set; } = "und";
+    public string LanguageName { get; set; } = "Undetermined";
+    public string Codec { get; set; } = string.Empty;
+    public bool IsForced { get; set; }
+    public bool IsHearingImpaired { get; set; }
+
+    // IMediaTrack — fixed shape for a planned external subtitle track.
+    public int Index => 0;
+    public MediaTrackType Type => MediaTrackType.Subtitles;
+    public string? Name => null;
+    public int AudioChannels => 0;
+    public long DurationMs => 0;
+    public bool IsDefault => false;
+    public bool IsCommentary => false;
+    public bool IsVisualImpaired => false;
+    public bool IsOriginal => false;
+    public bool IsDub => false;
+}

--- a/Muxarr.Core/Utilities/ExternalSubtitleDetector.cs
+++ b/Muxarr.Core/Utilities/ExternalSubtitleDetector.cs
@@ -1,0 +1,79 @@
+using Muxarr.Core.Language;
+using Muxarr.Core.Models;
+using Muxarr.Core.MkvToolNix;
+
+namespace Muxarr.Core.Utilities;
+
+public static class ExternalSubtitleDetector
+{
+    // Extension -> codec name understood by SubtitleCodecExtensions.ParseSubtitleCodec.
+    private static readonly Dictionary<string, string> SubtitleExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        [".srt"] = "Srt",
+        [".ass"] = "Ass",
+        [".ssa"] = "Ass",
+        [".sup"] = "Pgs",
+        [".vtt"] = "WebVtt"
+    };
+
+    /// <summary>
+    /// Parses one sibling file against a video stem. Returns null when the file
+    /// is not a subtitle for this video (wrong stem or wrong extension).
+    /// </summary>
+    public static ExternalSubtitle? ParseFromFileName(string videoStem, string subtitleFileName)
+    {
+        var ext = System.IO.Path.GetExtension(subtitleFileName);
+        if (string.IsNullOrEmpty(ext) || !SubtitleExtensions.TryGetValue(ext, out var codec))
+        {
+            return null;
+        }
+
+        var nameNoExt = System.IO.Path.GetFileNameWithoutExtension(subtitleFileName);
+
+        // Must be "<videoStem>" or "<videoStem>.<tokens>".
+        if (!nameNoExt.Equals(videoStem, StringComparison.OrdinalIgnoreCase)
+            && !nameNoExt.StartsWith(videoStem + ".", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        var tokenPart = nameNoExt.Length > videoStem.Length
+            ? nameNoExt.Substring(videoStem.Length).Trim('.')
+            : string.Empty;
+        var tokens = tokenPart.Length == 0
+            ? Array.Empty<string>()
+            : tokenPart.Split('.', StringSplitOptions.RemoveEmptyEntries);
+
+        var sub = new ExternalSubtitle { Codec = codec };
+
+        foreach (var token in tokens)
+        {
+            if (token.Equals("forced", StringComparison.OrdinalIgnoreCase))
+            {
+                sub.IsForced = true;
+                continue;
+            }
+
+            if (token.Equals("sdh", StringComparison.OrdinalIgnoreCase)
+                || token.Equals("hi", StringComparison.OrdinalIgnoreCase)
+                || token.Equals("cc", StringComparison.OrdinalIgnoreCase))
+            {
+                sub.IsHearingImpaired = true;
+                continue;
+            }
+
+            // First token that resolves to a known language wins.
+            if (sub.LanguageCode == "und")
+            {
+                var iso = IsoLanguage.Find(token);
+                if (iso != IsoLanguage.Unknown && iso.ThreeLetterCode is { } code)
+                {
+                    sub.LanguageCode = code;
+                    sub.LanguageName = iso.Name;
+                }
+            }
+        }
+
+        return sub;
+    }
+}

--- a/Muxarr.Core/Utilities/ExternalSubtitleDetector.cs
+++ b/Muxarr.Core/Utilities/ExternalSubtitleDetector.cs
@@ -20,15 +20,16 @@ public static class ExternalSubtitleDetector
     /// Parses one sibling file against a video stem. Returns null when the file
     /// is not a subtitle for this video (wrong stem or wrong extension).
     /// </summary>
+    /// <remarks>Stem matching is prefix-based ("&lt;videoStem&gt;" or "&lt;videoStem&gt;.&lt;tokens&gt;"); callers (see Detect) pass only sibling files from the same directory as the video.</remarks>
     public static ExternalSubtitle? ParseFromFileName(string videoStem, string subtitleFileName)
     {
-        var ext = System.IO.Path.GetExtension(subtitleFileName);
+        var ext = Path.GetExtension(subtitleFileName);
         if (string.IsNullOrEmpty(ext) || !SubtitleExtensions.TryGetValue(ext, out var codec))
         {
             return null;
         }
 
-        var nameNoExt = System.IO.Path.GetFileNameWithoutExtension(subtitleFileName);
+        var nameNoExt = Path.GetFileNameWithoutExtension(subtitleFileName);
 
         // Must be "<videoStem>" or "<videoStem>.<tokens>".
         if (!nameNoExt.Equals(videoStem, StringComparison.OrdinalIgnoreCase)
@@ -62,6 +63,7 @@ public static class ExternalSubtitleDetector
                 continue;
             }
 
+            // Resolve language last so flag tokens (forced/sdh/hi/cc) are never reinterpreted as a language code.
             // First token that resolves to a known language wins.
             if (sub.LanguageCode == "und")
             {

--- a/Muxarr.Core/Utilities/ExternalSubtitleDetector.cs
+++ b/Muxarr.Core/Utilities/ExternalSubtitleDetector.cs
@@ -16,6 +16,39 @@ public static class ExternalSubtitleDetector
         [".vtt"] = "WebVtt"
     };
 
+    // Only .mkv targets get external subs (webm subtitle support is constrained
+    // to WebVTT; MP4 needs mov_text re-encoding) — see the design doc.
+    public static IReadOnlyList<ExternalSubtitle> Detect(string videoPath)
+    {
+        if (!Path.GetExtension(videoPath).Equals(".mkv", StringComparison.OrdinalIgnoreCase))
+        {
+            return Array.Empty<ExternalSubtitle>();
+        }
+
+        var dir = Path.GetDirectoryName(videoPath);
+        if (string.IsNullOrEmpty(dir) || !Directory.Exists(dir))
+        {
+            return Array.Empty<ExternalSubtitle>();
+        }
+
+        var stem = Path.GetFileNameWithoutExtension(videoPath);
+        var result = new List<ExternalSubtitle>();
+
+        foreach (var file in Directory.EnumerateFiles(dir))
+        {
+            var sub = ParseFromFileName(stem, Path.GetFileName(file));
+            if (sub == null)
+            {
+                continue;
+            }
+
+            sub.Path = file;
+            result.Add(sub);
+        }
+
+        return result;
+    }
+
     /// <summary>
     /// Parses one sibling file against a video stem. Returns null when the file
     /// is not a subtitle for this video (wrong stem or wrong extension).

--- a/Muxarr.Data/Entities/MediaFile.cs
+++ b/Muxarr.Data/Entities/MediaFile.cs
@@ -1,5 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Muxarr.Core.Models;
+using Muxarr.Data.Extensions;
 
 namespace Muxarr.Data.Entities;
 
@@ -15,6 +17,8 @@ public class MediaFile : AuditableEntity
     public bool HasScanWarning { get; set; }
     public bool HasRedundantTracks { get; set; }
     public bool HasNonStandardMetadata { get; set; }
+    public bool HasExternalSubtitles { get; set; }
+    public List<ExternalSubtitle> ExternalSubtitles { get; set; } = new();
     public bool IsHardlinked { get; set; }
     public DateTime FileLastWriteTime { get; set; }
     public DateTime FileCreationTime { get; set; }
@@ -61,6 +65,13 @@ public class MediaFileConfiguration : AuditEntityConfiguration<MediaFile>
 
         builder.Property(e => e.HasNonStandardMetadata)
             .IsRequired();
+
+        builder.Property(e => e.HasExternalSubtitles)
+            .IsRequired()
+            .HasDefaultValue(false);
+
+        builder.Property(e => e.ExternalSubtitles)
+            .HasJsonConversion();
 
         builder.Property(e => e.IsHardlinked)
             .IsRequired()

--- a/Muxarr.Data/Entities/Profile.cs
+++ b/Muxarr.Data/Entities/Profile.cs
@@ -87,6 +87,8 @@ public class Profile : AuditableEntity
     public List<string> Directories { get; set; } = new();
     public bool ClearVideoTrackNames { get; set; }
     public bool SkipHardlinkedFiles { get; set; }
+    public bool ImportExternalSubtitles { get; set; }
+    public bool DeleteExternalSubtitleSource { get; set; }
     public TrackSettings AudioSettings { get; set; } = new();
     public TrackSettings SubtitleSettings { get; set; } = new();
     public ICollection<MediaFile> MediaFiles { get; set; } = new List<MediaFile>();
@@ -165,6 +167,14 @@ public class ProfileConfiguration : AuditEntityConfiguration<Profile>
             .HasDefaultValue(false);
 
         builder.Property(e => e.SkipHardlinkedFiles)
+            .IsRequired()
+            .HasDefaultValue(false);
+
+        builder.Property(e => e.ImportExternalSubtitles)
+            .IsRequired()
+            .HasDefaultValue(false);
+
+        builder.Property(e => e.DeleteExternalSubtitleSource)
             .IsRequired()
             .HasDefaultValue(false);
 

--- a/Muxarr.Data/Extensions/ConversionPlanExtensions.cs
+++ b/Muxarr.Data/Extensions/ConversionPlanExtensions.cs
@@ -39,6 +39,7 @@ public static class ConversionPlanExtensions
             Index = desired.Index,
             Type = desired.Type,
             NameLocked = desired.NameLocked,
+            SourcePath = desired.SourcePath,
 
             Name = DiffString(source?.Name, desired.Name),
             LanguageCode = DiffString(source?.LanguageCode, desired.LanguageCode),

--- a/Muxarr.Data/Extensions/MediaFileExtensions.cs
+++ b/Muxarr.Data/Extensions/MediaFileExtensions.cs
@@ -888,8 +888,65 @@ public static class MediaFileExtensions
             }).ToList()
         };
 
+        AppendExternalSubtitles(file, profile, allowed, target);
         TargetResolver.ResolveForContainer(target, file.ToMediaSnapshot());
         return target;
+    }
+
+    // Appends qualifying external subtitle files to the target plan. Runs only
+    // for Matroska targets when the profile opts in. Dedup is language-only
+    // against the kept internal subtitle tracks; survivors then pass through the
+    // same keep-list / priority / limit logic as internal subs.
+    private static void AppendExternalSubtitles(MediaFile file, Profile profile,
+        List<TrackSnapshot> keptInternal, ConversionPlan target)
+    {
+        if (!profile.ImportExternalSubtitles
+            || file.ExternalSubtitles.Count == 0
+            || file.Snapshot.ContainerType.ToContainerFamily() != ContainerFamily.Matroska)
+        {
+            return;
+        }
+
+        var keptSubLanguages = keptInternal
+            .GetSubtitleTracks()
+            .Select(t => t.LanguageName)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var candidates = file.ExternalSubtitles
+            .Where(e => !keptSubLanguages.Contains(e.LanguageName))
+            .ToList();
+
+        if (candidates.Count == 0)
+        {
+            return;
+        }
+
+        // Same keep-list / RemoveImpaired / ExcludeCodecs / MaxTracks / reorder
+        // path as internal subs. ExternalSubtitle implements IMediaTrack, so the
+        // returned list is the surviving ExternalSubtitle references (Path intact).
+        var kept = candidates.GetAllowedTracks(profile.SubtitleSettings, file.OriginalLanguage);
+        if (kept.Count == 0)
+        {
+            return;
+        }
+
+        var nextIndex = file.Snapshot.Tracks.Count == 0
+            ? 0
+            : file.Snapshot.Tracks.Max(t => t.Index) + 1;
+
+        foreach (var external in kept)
+        {
+            var snapshot = external.ToSnapshot();
+            snapshot.ApplyTrackMutations(profile.SubtitleSettings, kept.Count, file.OriginalLanguage,
+                profile.SubtitleSettings.StandardizeTrackNames);
+
+            var plan = snapshot.ToTargetTrack(nameLocked: false);
+            plan.Index = nextIndex++;
+            plan.SourcePath = external.Path;
+            // External subs are never the default track; the container keeps its own.
+            plan.IsDefault = false;
+            target.Tracks.Add(plan);
+        }
     }
 
     // Custom-conversion desired state. User input is authoritative. The UI's

--- a/Muxarr.Data/Extensions/MediaFileExtensions.cs
+++ b/Muxarr.Data/Extensions/MediaFileExtensions.cs
@@ -930,6 +930,15 @@ public static class MediaFileExtensions
             return;
         }
 
+        // Undetermined-language resolution must consider every subtitle track in
+        // the output (internal kept + external), not just the external survivors,
+        // so the "single und track" heuristic does not mis-fire.
+        var totalSubtitleTracks = keptInternal.GetSubtitleTracks().Count + kept.Count;
+
+        // Synthetic indices continue after the highest container track index so
+        // they never collide. Safe because Snapshot.Tracks holds only
+        // actually-included tracks (mkvmerge IDs are compact 0-based), and this
+        // path is Matroska-only.
         var nextIndex = file.Snapshot.Tracks.Count == 0
             ? 0
             : file.Snapshot.Tracks.Max(t => t.Index) + 1;
@@ -937,7 +946,7 @@ public static class MediaFileExtensions
         foreach (var external in kept)
         {
             var snapshot = external.ToSnapshot();
-            snapshot.ApplyTrackMutations(profile.SubtitleSettings, kept.Count, file.OriginalLanguage,
+            snapshot.ApplyTrackMutations(profile.SubtitleSettings, totalSubtitleTracks, file.OriginalLanguage,
                 profile.SubtitleSettings.StandardizeTrackNames);
 
             var plan = snapshot.ToTargetTrack(nameLocked: false);

--- a/Muxarr.Data/Extensions/ProfileExtensions.cs
+++ b/Muxarr.Data/Extensions/ProfileExtensions.cs
@@ -21,6 +21,8 @@ public static class ProfileExtensions
         clone.Id = profile.Id;
         clone.ClearVideoTrackNames = profile.ClearVideoTrackNames;
         clone.SkipHardlinkedFiles = profile.SkipHardlinkedFiles;
+        clone.ImportExternalSubtitles = profile.ImportExternalSubtitles;
+        clone.DeleteExternalSubtitleSource = profile.DeleteExternalSubtitleSource;
         return clone;
     }
 }

--- a/Muxarr.Data/Migrations/20260530122623_AddExternalSubtitleImport.Designer.cs
+++ b/Muxarr.Data/Migrations/20260530122623_AddExternalSubtitleImport.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Muxarr.Data;
 
@@ -10,9 +11,11 @@ using Muxarr.Data;
 namespace Muxarr.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260530122623_AddExternalSubtitleImport")]
+    partial class AddExternalSubtitleImport
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.5");

--- a/Muxarr.Data/Migrations/20260530122623_AddExternalSubtitleImport.cs
+++ b/Muxarr.Data/Migrations/20260530122623_AddExternalSubtitleImport.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Muxarr.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddExternalSubtitleImport : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "DeleteExternalSubtitleSource",
+                table: "Profile",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "ImportExternalSubtitles",
+                table: "Profile",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ExternalSubtitles",
+                table: "MediaFile",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "HasExternalSubtitles",
+                table: "MediaFile",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DeleteExternalSubtitleSource",
+                table: "Profile");
+
+            migrationBuilder.DropColumn(
+                name: "ImportExternalSubtitles",
+                table: "Profile");
+
+            migrationBuilder.DropColumn(
+                name: "ExternalSubtitles",
+                table: "MediaFile");
+
+            migrationBuilder.DropColumn(
+                name: "HasExternalSubtitles",
+                table: "MediaFile");
+        }
+    }
+}

--- a/Muxarr.Tests/ConversionPlanExtensionsTests.cs
+++ b/Muxarr.Tests/ConversionPlanExtensionsTests.cs
@@ -65,10 +65,35 @@ public class ConversionPlanExtensionsTests
         }
     }
 
+    [TestMethod]
+    public void Delta_PreservesSourcePathOnExternalTrack()
+    {
+        var source = new MediaSnapshot { Tracks = new List<TrackSnapshot>() };
+        var desired = new ConversionPlan
+        {
+            Tracks = new List<TrackPlan>
+            {
+                new()
+                {
+                    Index = 100,
+                    Type = MediaTrackType.Subtitles,
+                    LanguageCode = "eng",
+                    SourcePath = "/media/Elemental.eng.srt"
+                }
+            }
+        };
+
+        var delta = ConversionPlanExtensions.Delta(source, desired);
+
+        Assert.AreEqual("/media/Elemental.eng.srt", delta.Tracks[0].SourcePath);
+        Assert.AreEqual(100, delta.Tracks[0].Index);
+    }
+
     private static IEnumerable<PropertyInfo> DiffableFields => typeof(TrackPlan)
         .GetProperties(BindingFlags.Public | BindingFlags.Instance)
         .Where(p => p.CanWrite && (Nullable.GetUnderlyingType(p.PropertyType) is not null
-                                   || p.PropertyType == typeof(string)));
+                                   || p.PropertyType == typeof(string))
+                               && p.Name != nameof(TrackPlan.SourcePath));
 
     private static object Distinct(Type type, object? current)
     {

--- a/Muxarr.Tests/ExtensionTests.cs
+++ b/Muxarr.Tests/ExtensionTests.cs
@@ -11,6 +11,23 @@ namespace Muxarr.Tests;
 public class ExtensionTests
 {
     [TestMethod]
+    public void ProfileClone_CopiesExternalSubtitleFlags()
+    {
+        var profile = new Profile
+        {
+            Id = 7,
+            Name = "Test",
+            ImportExternalSubtitles = true,
+            DeleteExternalSubtitleSource = true
+        };
+
+        var clone = profile.Clone();
+
+        Assert.IsTrue(clone.ImportExternalSubtitles);
+        Assert.IsTrue(clone.DeleteExternalSubtitleSource);
+    }
+
+    [TestMethod]
     public void ParseCodec_MapsKnownCodecs()
     {
         Assert.AreEqual(nameof(VideoCodec.Hevc), CodecExtensions.ParseCodec("HEVC"));

--- a/Muxarr.Tests/ExternalSubtitleDetectorTests.cs
+++ b/Muxarr.Tests/ExternalSubtitleDetectorTests.cs
@@ -74,4 +74,50 @@ public class ExternalSubtitleDetectorTests
         var sub = ExternalSubtitleDetector.ParseFromFileName("Elemental", "Elemental.eng.txt");
         Assert.IsNull(sub);
     }
+
+    [TestMethod]
+    public void Detect_FindsMatchingSiblingsOnly()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "muxarr-extsub-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var video = Path.Combine(dir, "Elemental.mkv");
+            File.WriteAllText(video, "x");
+            File.WriteAllText(Path.Combine(dir, "Elemental.eng.srt"), "x");
+            File.WriteAllText(Path.Combine(dir, "Elemental.ro.srt"), "x");
+            File.WriteAllText(Path.Combine(dir, "OtherMovie.eng.srt"), "x");
+            File.WriteAllText(Path.Combine(dir, "Elemental.nfo"), "x");
+
+            var subs = ExternalSubtitleDetector.Detect(video);
+
+            CollectionAssert.AreEquivalent(
+                new[] { "English", "Romanian" },
+                subs.Select(s => s.LanguageName).ToList());
+            Assert.IsTrue(subs.All(s => Path.GetFileName(s.Path).StartsWith("Elemental.")));
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [TestMethod]
+    public void Detect_NonMkvVideo_ReturnsEmpty()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "muxarr-extsub-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var video = Path.Combine(dir, "Elemental.mp4");
+            File.WriteAllText(video, "x");
+            File.WriteAllText(Path.Combine(dir, "Elemental.eng.srt"), "x");
+
+            Assert.AreEqual(0, ExternalSubtitleDetector.Detect(video).Count);
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
 }

--- a/Muxarr.Tests/ExternalSubtitleDetectorTests.cs
+++ b/Muxarr.Tests/ExternalSubtitleDetectorTests.cs
@@ -1,0 +1,75 @@
+using Muxarr.Core.Models;
+using Muxarr.Core.Utilities;
+
+namespace Muxarr.Tests;
+
+[TestClass]
+public class ExternalSubtitleDetectorTests
+{
+    [TestMethod]
+    public void Parse_ThreeLetterLanguage_SetsLanguage()
+    {
+        var sub = ExternalSubtitleDetector.ParseFromFileName("Elemental", "Elemental.eng.srt");
+
+        Assert.IsNotNull(sub);
+        Assert.AreEqual("eng", sub.LanguageCode);
+        Assert.AreEqual("English", sub.LanguageName);
+        Assert.AreEqual("Srt", sub.Codec);
+        Assert.IsFalse(sub.IsForced);
+        Assert.IsFalse(sub.IsHearingImpaired);
+    }
+
+    [TestMethod]
+    public void Parse_TwoLetterLanguage_Resolves()
+    {
+        var sub = ExternalSubtitleDetector.ParseFromFileName("Elemental", "Elemental.en.srt");
+        Assert.IsNotNull(sub);
+        Assert.AreEqual("English", sub!.LanguageName);
+    }
+
+    [TestMethod]
+    public void Parse_ForcedToken_SetsForcedFlag()
+    {
+        var sub = ExternalSubtitleDetector.ParseFromFileName("Elemental", "Elemental.eng.forced.srt");
+        Assert.IsNotNull(sub);
+        Assert.AreEqual("English", sub!.LanguageName);
+        Assert.IsTrue(sub.IsForced);
+    }
+
+    [TestMethod]
+    public void Parse_SdhToken_SetsHearingImpairedFlag()
+    {
+        var sub = ExternalSubtitleDetector.ParseFromFileName("Elemental", "Elemental.eng.sdh.srt");
+        Assert.IsTrue(sub!.IsHearingImpaired);
+    }
+
+    [TestMethod]
+    public void Parse_BareSubtitle_DefaultsToUndetermined()
+    {
+        var sub = ExternalSubtitleDetector.ParseFromFileName("Elemental", "Elemental.srt");
+        Assert.IsNotNull(sub);
+        Assert.AreEqual("und", sub!.LanguageCode);
+        Assert.AreEqual("Undetermined", sub.LanguageName);
+    }
+
+    [TestMethod]
+    public void Parse_AssExtension_MapsCodec()
+    {
+        var sub = ExternalSubtitleDetector.ParseFromFileName("Elemental", "Elemental.eng.ass");
+        Assert.AreEqual("Ass", sub!.Codec);
+    }
+
+    [TestMethod]
+    public void Parse_DifferentStem_ReturnsNull()
+    {
+        var sub = ExternalSubtitleDetector.ParseFromFileName("Elemental", "OtherMovie.eng.srt");
+        Assert.IsNull(sub);
+    }
+
+    [TestMethod]
+    public void Parse_NonSubtitleExtension_ReturnsNull()
+    {
+        var sub = ExternalSubtitleDetector.ParseFromFileName("Elemental", "Elemental.eng.txt");
+        Assert.IsNull(sub);
+    }
+}

--- a/Muxarr.Tests/ExternalSubtitleDetectorTests.cs
+++ b/Muxarr.Tests/ExternalSubtitleDetectorTests.cs
@@ -40,6 +40,7 @@ public class ExternalSubtitleDetectorTests
     public void Parse_SdhToken_SetsHearingImpairedFlag()
     {
         var sub = ExternalSubtitleDetector.ParseFromFileName("Elemental", "Elemental.eng.sdh.srt");
+        Assert.IsNotNull(sub);
         Assert.IsTrue(sub!.IsHearingImpaired);
     }
 
@@ -56,6 +57,7 @@ public class ExternalSubtitleDetectorTests
     public void Parse_AssExtension_MapsCodec()
     {
         var sub = ExternalSubtitleDetector.ParseFromFileName("Elemental", "Elemental.eng.ass");
+        Assert.IsNotNull(sub);
         Assert.AreEqual("Ass", sub!.Codec);
     }
 

--- a/Muxarr.Tests/ExternalSubtitleImportTests.cs
+++ b/Muxarr.Tests/ExternalSubtitleImportTests.cs
@@ -63,7 +63,7 @@ public class ExternalSubtitleImportTests
         Assert.AreEqual(1, external.Count);
         Assert.AreEqual("/media/Elemental.eng.srt", external[0].SourcePath);
         Assert.AreEqual("eng", external[0].LanguageCode);
-        Assert.IsTrue(external[0].Index > 0, "external track gets a synthetic index after container tracks");
+        Assert.AreEqual(1, external[0].Index, "external track gets a synthetic index after container tracks");
     }
 
     [TestMethod]
@@ -129,5 +129,35 @@ public class ExternalSubtitleImportTests
         var target = file.BuildTargetFromProfile(EnglishOnlyProfile(import: true));
 
         Assert.AreEqual(0, target.Tracks.Count(t => t.SourcePath != null));
+    }
+
+    [TestMethod]
+    public void Import_RespectsPerLanguageMaxTracksLimit()
+    {
+        var file = MkvFileWith(
+            new List<TrackSnapshot> { Video() },
+            new List<ExternalSubtitle>
+            {
+                new() { Path = "/media/Elemental.en.srt", LanguageCode = "eng", LanguageName = "English", Codec = "Srt" },
+                new() { Path = "/media/Elemental.eng.srt", LanguageCode = "eng", LanguageName = "English", Codec = "Srt" }
+            });
+
+        var profile = new Profile
+        {
+            ImportExternalSubtitles = true,
+            SubtitleSettings = new TrackSettings
+            {
+                Enabled = true,
+                AllowedLanguages = new List<LanguagePreference>
+                {
+                    new() { Language = IsoLanguage.Find("eng"), MaxTracks = 1 }
+                }
+            }
+        };
+
+        var target = file.BuildTargetFromProfile(profile);
+
+        Assert.AreEqual(1, target.Tracks.Count(t => t.SourcePath != null),
+            "two same-language external subs should be capped to MaxTracks=1");
     }
 }

--- a/Muxarr.Tests/ExternalSubtitleImportTests.cs
+++ b/Muxarr.Tests/ExternalSubtitleImportTests.cs
@@ -1,0 +1,133 @@
+using Muxarr.Core.Extensions;
+using Muxarr.Core.Language;
+using Muxarr.Core.Models;
+using Muxarr.Data.Entities;
+using Muxarr.Data.Extensions;
+
+namespace Muxarr.Tests;
+
+[TestClass]
+public class ExternalSubtitleImportTests
+{
+    private static MediaFile MkvFileWith(
+        List<TrackSnapshot> tracks,
+        List<ExternalSubtitle> external,
+        bool import = true)
+    {
+        var file = new MediaFile
+        {
+            Path = "/media/Elemental.mkv",
+            ExternalSubtitles = external,
+            Snapshot = new MediaSnapshot
+            {
+                ContainerType = "Matroska",
+                Tracks = tracks
+            }
+        };
+        return file;
+    }
+
+    private static Profile EnglishOnlyProfile(bool import)
+    {
+        return new Profile
+        {
+            ImportExternalSubtitles = import,
+            SubtitleSettings = new TrackSettings
+            {
+                Enabled = true,
+                // LanguagePreference.Name is computed from Language; set Language.
+                AllowedLanguages = new List<LanguagePreference>
+                {
+                    new() { Language = IsoLanguage.Find("eng") }
+                }
+            }
+        };
+    }
+
+    private static TrackSnapshot Video() => new()
+        { Index = 0, Type = MediaTrackType.Video, LanguageCode = "und", LanguageName = "Undetermined" };
+
+    [TestMethod]
+    public void Import_AddsExternalSubInKeptLanguage()
+    {
+        var file = MkvFileWith(
+            new List<TrackSnapshot> { Video() },
+            new List<ExternalSubtitle>
+            {
+                new() { Path = "/media/Elemental.eng.srt", LanguageCode = "eng", LanguageName = "English", Codec = "Srt" }
+            });
+
+        var target = file.BuildTargetFromProfile(EnglishOnlyProfile(import: true));
+
+        var external = target.Tracks.Where(t => t.SourcePath != null).ToList();
+        Assert.AreEqual(1, external.Count);
+        Assert.AreEqual("/media/Elemental.eng.srt", external[0].SourcePath);
+        Assert.AreEqual("eng", external[0].LanguageCode);
+        Assert.IsTrue(external[0].Index > 0, "external track gets a synthetic index after container tracks");
+    }
+
+    [TestMethod]
+    public void Import_DropsLanguageNotInKeepList()
+    {
+        var file = MkvFileWith(
+            new List<TrackSnapshot> { Video() },
+            new List<ExternalSubtitle>
+            {
+                new() { Path = "/media/Elemental.ro.srt", LanguageCode = "ron", LanguageName = "Romanian", Codec = "Srt" }
+            });
+
+        var target = file.BuildTargetFromProfile(EnglishOnlyProfile(import: true));
+
+        Assert.AreEqual(0, target.Tracks.Count(t => t.SourcePath != null));
+    }
+
+    [TestMethod]
+    public void Import_SkipsWhenInternalLanguageAlreadyPresent()
+    {
+        var internalEng = new TrackSnapshot
+        {
+            Index = 1, Type = MediaTrackType.Subtitles, LanguageCode = "eng", LanguageName = "English", Codec = "Srt"
+        };
+        var file = MkvFileWith(
+            new List<TrackSnapshot> { Video(), internalEng },
+            new List<ExternalSubtitle>
+            {
+                new() { Path = "/media/Elemental.eng.srt", LanguageCode = "eng", LanguageName = "English", Codec = "Srt" }
+            });
+
+        var target = file.BuildTargetFromProfile(EnglishOnlyProfile(import: true));
+
+        Assert.AreEqual(0, target.Tracks.Count(t => t.SourcePath != null));
+    }
+
+    [TestMethod]
+    public void Import_Disabled_AddsNothing()
+    {
+        var file = MkvFileWith(
+            new List<TrackSnapshot> { Video() },
+            new List<ExternalSubtitle>
+            {
+                new() { Path = "/media/Elemental.eng.srt", LanguageCode = "eng", LanguageName = "English", Codec = "Srt" }
+            });
+
+        var target = file.BuildTargetFromProfile(EnglishOnlyProfile(import: false));
+
+        Assert.AreEqual(0, target.Tracks.Count(t => t.SourcePath != null));
+    }
+
+    [TestMethod]
+    public void Import_NonMkvContainer_AddsNothing()
+    {
+        var file = MkvFileWith(
+            new List<TrackSnapshot> { Video() },
+            new List<ExternalSubtitle>
+            {
+                new() { Path = "/media/Elemental.eng.srt", LanguageCode = "eng", LanguageName = "English", Codec = "Srt" }
+            });
+        file.Snapshot.ContainerType = "QuickTime/MP4"; // non-Matroska
+
+        var target = file.BuildTargetFromProfile(EnglishOnlyProfile(import: true));
+
+        Assert.AreEqual(0, target.Tracks.Count(t => t.SourcePath != null));
+    }
+}

--- a/Muxarr.Tests/Integration/ExternalSubtitleMuxTests.cs
+++ b/Muxarr.Tests/Integration/ExternalSubtitleMuxTests.cs
@@ -1,0 +1,48 @@
+using Muxarr.Core.Models;
+using Muxarr.Core.MkvToolNix;
+using Muxarr.Data.Entities;
+using Muxarr.Data.Extensions;
+
+namespace Muxarr.Tests.Integration;
+
+[TestClass]
+public class ExternalSubtitleMuxTests : IntegrationTestBase
+{
+    [TestMethod]
+    public async Task Remux_MuxesExternalFrenchSubtitleIntoMkv()
+    {
+        var path = CopyFixture("test.mkv", "Movie.mkv");
+        File.WriteAllText(Path.Combine(TempDir, "Movie.fre.srt"),
+            "1\n00:00:00,000 --> 00:00:02,000\nBonjour.\n");
+
+        var profile = await Fixture.WithDbContext(async ctx =>
+        {
+            var p = new Profile
+            {
+                Name = "ext-subs-mux",
+                Directories = new List<string> { TempDir },
+                ImportExternalSubtitles = true,
+                AudioSettings = new TrackSettings(),
+                SubtitleSettings = new TrackSettings() // Enabled = false: keep all internal subs, import new languages
+            };
+            ctx.Profiles.Add(p);
+            await ctx.SaveChangesAsync();
+            return p;
+        });
+
+        var file = await Fixture.ScanAndPersist(path, profile);
+
+        var plan = file.BuildTargetFromProfile(profile);
+        Assert.IsTrue(plan.Tracks.Any(t => t.SourcePath != null), "plan should include the external sub");
+
+        var output = Path.Combine(TempDir, "out.mkv");
+        var delta = ConversionPlanExtensions.Delta(file.Snapshot, plan);
+        var result = await MkvMerge.Remux(file.Path, output, delta);
+
+        Assert.IsTrue(MkvMerge.IsSuccess(result), $"mkvmerge failed: {result.Error} {result.Output}");
+        var info = await MkvMerge.GetFileInfo(output);
+        Assert.IsTrue(info.Result!.Tracks.Any(t =>
+            t.Type == "subtitles" && t.Properties.Language == "fre"),
+            "output should contain a French subtitle track");
+    }
+}

--- a/Muxarr.Tests/Integration/ExternalSubtitleScanTests.cs
+++ b/Muxarr.Tests/Integration/ExternalSubtitleScanTests.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore;
+using Muxarr.Data;
+using Muxarr.Data.Entities;
+
+namespace Muxarr.Tests.Integration;
+
+[TestClass]
+public class ExternalSubtitleScanTests : IntegrationTestBase
+{
+    [TestMethod]
+    public async Task Scan_PopulatesExternalSubtitlesAndFlag()
+    {
+        var path = CopyFixture("test.mkv", "Movie.mkv");
+        File.WriteAllText(Path.Combine(TempDir, "Movie.fre.srt"),
+            "1\n00:00:00,000 --> 00:00:02,000\nBonjour.\n");
+
+        var profile = await Fixture.WithDbContext(async ctx =>
+        {
+            var p = new Profile
+            {
+                Name = "ext-subs",
+                Directories = new List<string> { TempDir },
+                ImportExternalSubtitles = true,
+                AudioSettings = new TrackSettings(),
+                SubtitleSettings = new TrackSettings() // Enabled = false: keep all internal, import new languages
+            };
+            ctx.Profiles.Add(p);
+            await ctx.SaveChangesAsync();
+            return p;
+        });
+
+        var file = await Fixture.ScanAndPersist(path, profile);
+
+        Assert.AreEqual(1, file.ExternalSubtitles.Count);
+        Assert.AreEqual("fre", file.ExternalSubtitles[0].LanguageCode);
+        Assert.IsTrue(file.HasExternalSubtitles);
+    }
+}

--- a/Muxarr.Tests/MkvMergeExternalInputTests.cs
+++ b/Muxarr.Tests/MkvMergeExternalInputTests.cs
@@ -1,0 +1,77 @@
+using Muxarr.Core.Models;
+using Muxarr.Core.MkvToolNix;
+
+namespace Muxarr.Tests;
+
+[TestClass]
+public class MkvMergeExternalInputTests
+{
+    private static ConversionPlan PlanWithExternal()
+    {
+        return new ConversionPlan
+        {
+            Tracks = new List<TrackPlan>
+            {
+                new() { Index = 0, Type = MediaTrackType.Video },
+                new() { Index = 1, Type = MediaTrackType.Audio, LanguageCode = "eng" },
+                new()
+                {
+                    Index = 100,
+                    Type = MediaTrackType.Subtitles,
+                    LanguageCode = "eng",
+                    SourcePath = "/media/Elemental.eng.srt"
+                }
+            }
+        };
+    }
+
+    [TestMethod]
+    public void Build_NoExternal_KeepsSingleInputShape()
+    {
+        var plan = new ConversionPlan
+        {
+            Tracks = new List<TrackPlan>
+            {
+                new() { Index = 0, Type = MediaTrackType.Video },
+                new() { Index = 1, Type = MediaTrackType.Audio }
+            }
+        };
+
+        var cmd = MkvMerge.BuildRemuxCommand("/media/in.mkv", "/media/out.mkv", plan);
+
+        StringAssert.Contains(cmd, "\"/media/in.mkv\"");
+        StringAssert.Contains(cmd, "--track-order 0:0,0:1");
+        Assert.IsFalse(cmd.Contains(".srt"), "no external input expected");
+    }
+
+    [TestMethod]
+    public void Build_External_AddsInputFileAfterContainer()
+    {
+        var cmd = MkvMerge.BuildRemuxCommand("/media/in.mkv", "/media/out.mkv", PlanWithExternal());
+
+        var containerIdx = cmd.IndexOf("\"/media/in.mkv\"", StringComparison.Ordinal);
+        var externalIdx = cmd.IndexOf("\"/media/Elemental.eng.srt\"", StringComparison.Ordinal);
+        Assert.IsTrue(containerIdx >= 0 && externalIdx > containerIdx,
+            "external input must appear after the container input");
+    }
+
+    [TestMethod]
+    public void Build_External_UsesLocalTrackIdZeroBeforeFile()
+    {
+        var cmd = MkvMerge.BuildRemuxCommand("/media/in.mkv", "/media/out.mkv", PlanWithExternal());
+
+        // The external file's language option uses local track id 0, and appears
+        // before the .srt path.
+        var langIdx = cmd.IndexOf("--language 0:eng", cmd.IndexOf("\"/media/in.mkv\"", StringComparison.Ordinal) + 1,
+            StringComparison.Ordinal);
+        var externalIdx = cmd.IndexOf("\"/media/Elemental.eng.srt\"", StringComparison.Ordinal);
+        Assert.IsTrue(langIdx >= 0 && langIdx < externalIdx);
+    }
+
+    [TestMethod]
+    public void Build_External_TrackOrderUsesGlobalFileIds()
+    {
+        var cmd = MkvMerge.BuildRemuxCommand("/media/in.mkv", "/media/out.mkv", PlanWithExternal());
+        StringAssert.Contains(cmd, "--track-order 0:0,0:1,1:0");
+    }
+}

--- a/Muxarr.Tests/MkvMergeExternalInputTests.cs
+++ b/Muxarr.Tests/MkvMergeExternalInputTests.cs
@@ -60,10 +60,13 @@ public class MkvMergeExternalInputTests
     {
         var cmd = MkvMerge.BuildRemuxCommand("/media/in.mkv", "/media/out.mkv", PlanWithExternal());
 
+        const string containerToken = "\"/media/in.mkv\"";
+        var containerIdx = cmd.IndexOf(containerToken, StringComparison.Ordinal);
+        var afterContainer = containerIdx + containerToken.Length;
+
         // The external file's language option uses local track id 0, and appears
-        // before the .srt path.
-        var langIdx = cmd.IndexOf("--language 0:eng", cmd.IndexOf("\"/media/in.mkv\"", StringComparison.Ordinal) + 1,
-            StringComparison.Ordinal);
+        // after the container input and before the .srt path.
+        var langIdx = cmd.IndexOf("--language 0:eng", afterContainer, StringComparison.Ordinal);
         var externalIdx = cmd.IndexOf("\"/media/Elemental.eng.srt\"", StringComparison.Ordinal);
         Assert.IsTrue(langIdx >= 0 && langIdx < externalIdx);
     }
@@ -73,5 +76,26 @@ public class MkvMergeExternalInputTests
     {
         var cmd = MkvMerge.BuildRemuxCommand("/media/in.mkv", "/media/out.mkv", PlanWithExternal());
         StringAssert.Contains(cmd, "--track-order 0:0,0:1,1:0");
+    }
+
+    [TestMethod]
+    public void Build_TwoExternalFiles_NumbersInputsSequentially()
+    {
+        var plan = new ConversionPlan
+        {
+            Tracks = new List<TrackPlan>
+            {
+                new() { Index = 0, Type = MediaTrackType.Video },
+                new() { Index = 100, Type = MediaTrackType.Subtitles, LanguageCode = "eng", SourcePath = "/media/Movie.eng.srt" },
+                new() { Index = 101, Type = MediaTrackType.Subtitles, LanguageCode = "fre", SourcePath = "/media/Movie.fre.srt" }
+            }
+        };
+
+        var cmd = MkvMerge.BuildRemuxCommand("/media/in.mkv", "/media/out.mkv", plan);
+
+        StringAssert.Contains(cmd, "--track-order 0:0,1:0,2:0");
+        var engIdx = cmd.IndexOf("\"/media/Movie.eng.srt\"", StringComparison.Ordinal);
+        var freIdx = cmd.IndexOf("\"/media/Movie.fre.srt\"", StringComparison.Ordinal);
+        Assert.IsTrue(engIdx >= 0 && freIdx > engIdx, "first external path gets fileId 1, second gets fileId 2");
     }
 }

--- a/Muxarr.Web/Components/Pages/Library/Index.razor
+++ b/Muxarr.Web/Components/Pages/Library/Index.razor
@@ -97,6 +97,7 @@
                 <option value="tracks">Needs Track Removal</option>
                 <option value="metadata">Needs Metadata Fix</option>
                 <option value="any">Needs Any Work</option>
+                <option value="external">External Subs Available</option>
                 <option value="warnings">Has Scan Warning</option>
             </select>
             <button class="btn btn-sm @(_showAdvanced || HasAdvancedFilters ? "btn-primary" : "btn-outline-primary")"
@@ -471,6 +472,7 @@
             "tracks" => query.Where(x => x.HasRedundantTracks),
             "metadata" => query.Where(x => x.HasNonStandardMetadata),
             "any" => query.Where(x => x.HasRedundantTracks || x.HasNonStandardMetadata),
+            "external" => query.Where(x => x.HasExternalSubtitles),
             "warnings" => query.Where(x => x.HasScanWarning),
             _ => query
         };

--- a/Muxarr.Web/Components/Pages/Library/MediaTrackDetail.razor
+++ b/Muxarr.Web/Components/Pages/Library/MediaTrackDetail.razor
@@ -14,7 +14,7 @@
         }
     </td>
     <td>
-        <MediaTrackLabel Track="Track" ShowAllFlags="true"/>
+        <MediaTrackLabel Track="Track" ShowAllFlags="true" IsExternal="@(Preview?.SourcePath != null)"/>
         @if (ResolvedLanguage != null)
         {
             <i class="bi bi-arrow-right text-info mx-1" style="font-size: 0.7rem;"></i>

--- a/Muxarr.Web/Components/Pages/Library/MediaTrackDetailTable.razor
+++ b/Muxarr.Web/Components/Pages/Library/MediaTrackDetailTable.razor
@@ -26,6 +26,17 @@
             <td><i class="bi bi-x-circle-fill text-danger"></i> will be removed</td>
         </tr>
     }
+    @foreach (var preview in ExternalTracks)
+    {
+        <tr>
+            <td>@preview.Index</td>
+            <td>
+                <MediaTrackLabel Track="preview" ShowAllFlags="true" IsExternal="true"/>
+            </td>
+            <td><code>@(((IMediaTrack)preview).Codec.FormatCodec())</code></td>
+            <td><i class="bi bi-plus-circle-fill text-success"></i> will be muxed in from external file</td>
+        </tr>
+    }
     </tbody>
 </table>
 
@@ -38,6 +49,7 @@
 
     private List<TrackWithPreview> KeptTracks { get; set; } = [];
     private List<IMediaTrack> RemovedTracks { get; set; } = [];
+    private List<TrackPlan> ExternalTracks { get; set; } = [];
 
     protected override void OnParametersSet()
     {
@@ -45,6 +57,7 @@
         {
             KeptTracks = Tracks.Select(t => new TrackWithPreview(t, null, null)).ToList();
             RemovedTracks = [];
+            ExternalTracks = [];
             return;
         }
 
@@ -72,6 +85,7 @@
         }
 
         RemovedTracks = Tracks.Where(t => !previewByNumber.ContainsKey(t.Index)).ToList();
+        ExternalTracks = PreviewTracks.Where(p => p.SourcePath != null && Tracks.All(t => t.Index != p.Index)).ToList();
     }
 
 }

--- a/Muxarr.Web/Components/Pages/Library/MediaTrackLabel.razor
+++ b/Muxarr.Web/Components/Pages/Library/MediaTrackLabel.razor
@@ -38,12 +38,18 @@
             <ToolTip Tip="Default - player will auto-select this track"><i class="bi bi-play-circle ms-1"></i></ToolTip>
         }
     }
+    @if (IsExternal)
+    {
+        <span class="badge bg-info ms-1" title="Will be muxed in from an external file">external</span>
+    }
 </span>
 
 @code {
     [Parameter] [EditorRequired] public required IMediaTrack Track { get; set; }
 
     [Parameter] public bool ShowAllFlags { get; set; }
+
+    [Parameter] public bool IsExternal { get; set; }
 
     private static string GetTrackTypeIcon(MediaTrackType trackType)
     {

--- a/Muxarr.Web/Components/Pages/Settings/ProfileEdit.razor
+++ b/Muxarr.Web/Components/Pages/Settings/ProfileEdit.razor
@@ -98,6 +98,23 @@
                     {
                         <h5 class="mb-3"><i class="bi bi-chat-text text-primary me-2"></i>Subtitle Settings</h5>
                         <TrackSettingsEditor Settings="_profile.SubtitleSettings" TrackType="MediaTrackType.Subtitles"/>
+                        <div class="mb-3 form-check form-switch mt-3">
+                            <InputCheckbox id="importExternalSubs" class="form-check-input"
+                                           @bind-Value="_profile.ImportExternalSubtitles"/>
+                            <label class="form-check-label" for="importExternalSubs">Import external subtitle files</label>
+                            <small class="form-text text-muted d-block">Mux matching sibling subtitle files
+                                (e.g. <code>Movie.eng.srt</code>) into the MKV during processing. MKV only.</small>
+                        </div>
+                        @if (_profile.ImportExternalSubtitles)
+                        {
+                            <div class="mb-3 form-check form-switch ms-4">
+                                <InputCheckbox id="deleteExternalSubs" class="form-check-input"
+                                               @bind-Value="_profile.DeleteExternalSubtitleSource"/>
+                                <label class="form-check-label" for="deleteExternalSubs">Delete subtitle file after muxing</label>
+                                <small class="form-text text-muted d-block">Remove the original subtitle file once it has
+                                    been muxed in and the output validated.</small>
+                            </div>
+                        }
                     }
                 </div>
             </div>
@@ -181,6 +198,8 @@
                 existing.Directories = _profile.Directories;
                 existing.ClearVideoTrackNames = _profile.ClearVideoTrackNames;
                 existing.SkipHardlinkedFiles = _profile.SkipHardlinkedFiles;
+                existing.ImportExternalSubtitles = _profile.ImportExternalSubtitles;
+                existing.DeleteExternalSubtitleSource = _profile.DeleteExternalSubtitleSource;
                 existing.AudioSettings = _profile.AudioSettings;
                 existing.SubtitleSettings = _profile.SubtitleSettings;
                 context.Update(existing);

--- a/Muxarr.Web/Services/MediaConverterService.cs
+++ b/Muxarr.Web/Services/MediaConverterService.cs
@@ -661,6 +661,7 @@ public class MediaConverterService(
         conversion.SizeDifference = Math.Abs(conversion.SizeBefore - conversion.SizeAfter);
 
         await RunPostProcessing(conversion);
+        DeleteMuxedExternalSubtitles(conversion);
 
         conversion.State = ConversionState.Completed;
         conversion.Progress = 100;
@@ -675,6 +676,39 @@ public class MediaConverterService(
         catch (Exception ex)
         {
             logger.LogWarning(ex, "Failed to update conversion stats");
+        }
+    }
+
+    // Deletes the external subtitle files that were just muxed in, but only when
+    // the profile opts in. Called after the output is validated and the original
+    // replaced, so a failure earlier leaves the .srt files untouched. Deletion
+    // failures are logged, never fatal.
+    private void DeleteMuxedExternalSubtitles(MediaConversion conversion)
+    {
+        if (conversion.MediaFile?.Profile?.DeleteExternalSubtitleSource != true)
+        {
+            return;
+        }
+
+        var sources = conversion.ConversionPlan.Tracks
+            .Where(t => t.SourcePath != null)
+            .Select(t => t.SourcePath!)
+            .Distinct();
+
+        foreach (var path in sources)
+        {
+            try
+            {
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                    conversion.Log($"Deleted muxed subtitle source: {Path.GetFileName(path)}", logger);
+                }
+            }
+            catch (Exception ex)
+            {
+                conversion.LogError($"Could not delete subtitle source {Path.GetFileName(path)}: {ex.Message}", logger);
+            }
         }
     }
 

--- a/Muxarr.Web/Services/MediaScannerService.cs
+++ b/Muxarr.Web/Services/MediaScannerService.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using Muxarr.Core.Config;
 using Muxarr.Core.Extensions;
 using Muxarr.Core.FFmpeg;
+using Muxarr.Core.Models;
 using Muxarr.Core.Utilities;
 using Muxarr.Data;
 using Muxarr.Data.Entities;
@@ -295,10 +296,15 @@ public class MediaScannerService(
                     logger.LogInformation("ffprobe warning for '{Path}': {Warning}", dbFile.Path, probe.Error);
                 }
 
+                dbFile.ExternalSubtitles = ExternalSubtitleDetector.Detect(dbFile.Path).ToList();
+
                 var target = dbFile.BuildTargetFromProfile(profile);
                 var trackCount = dbFile.Snapshot.TrackCount;
                 dbFile.HasRedundantTracks = profile != null && target.Tracks.Count < trackCount;
                 dbFile.HasNonStandardMetadata = dbFile.CheckHasNonStandardMetadata(profile, target);
+                dbFile.HasExternalSubtitles = profile != null
+                                              && profile.ImportExternalSubtitles
+                                              && target.Tracks.Any(t => t.SourcePath != null);
             }
 
             dbFile.Size = fileInfo.Length;


### PR DESCRIPTION
Closes #36.

Detects subtitle files sitting next to a video (e.g. `Elemental.eng.srt` beside `Elemental.mkv`) and muxes them into the MKV during processing — stream-copy only, zero re-encode, via mkvmerge additional inputs.

## Maps to the request in #36
- Detects sibling subtitle files with matching names (`.srt` / `.ass` / `.ssa` / `.sup` / `.vtt`)
- Language **and** flags (`forced` / `sdh` / `hi` / `cc`) parsed from the filename; bare `Movie.srt` → `und`
- **Dedup:** skips an external sub whose language already exists as an internal subtitle
- **Optional delete-after**, only once the output is validated and the original safely replaced

## Design
External subs are appended to the desired `ConversionPlan` as tracks carrying a new `SourcePath`, so they reuse the existing machinery rather than a parallel code path:
- per-profile subtitle keep-list / priority / per-language limit logic
- the planner's structural-change → remux selection (extra tracks force a real remux automatically)
- the library track preview (external tracks show a badge)
- `OutputValidator` (verifies the muxed result before the original is replaced — safe by default)

`MkvMerge.Remux` is extended to add each external file as its own mkvmerge input (per-file-local track ids; only `--track-order` uses global ids). MKV-family only — MP4/webm are intentionally out of scope (mov_text re-encoding / WebVTT constraints). Per-profile opt-in under **Subtitle settings** with a **delete-after** sub-toggle; adds one EF migration (`AddExternalSubtitleImport`).

## Self-healing
Because muxed subs become internal tracks, the language-only dedup skips them on the next scan even if the `.srt` is left on disk — no re-import loop.

## Tests
- Unit: filename parsing, plan injection + dedup + keep-list/limit, mkvmerge multi-input command building
- Integration: real-fixture tests that actually mux an `.srt` into an `.mkv` and assert the track lands with the right language
- Full suite green (519 passed)

## Out of scope
MP4/webm muxing, downloading subtitles (Bazarr's job), and subtitle format conversion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)