### PR TITLE
Use /config for appdata and /data for media in Docker installs

### DIFF
--- a/Muxarr.Data/Configurator.cs
+++ b/Muxarr.Data/Configurator.cs
@@ -1,4 +1,5 @@
 using System.Data.Common;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -30,6 +31,7 @@ public static class Configurator
 
     public static async Task Initialize(this AppDbContext context, ILogger? logger = null)
     {
+        await MigrateLegacyDatabaseLocation(context, logger);
         var migrated = await BackupBeforeMigration(context, logger);
         await context.Database.MigrateAsync();
 
@@ -59,6 +61,126 @@ public static class Configurator
             webhookConfig.ApiKey = Guid.NewGuid().ToString("N");
             context.Configs.Set(webhookConfig);
             await context.SaveChangesAsync();
+        }
+    }
+
+    /// <summary>
+    /// Copies legacy container app data from /data to /config on first startup,
+    /// then archives the old database next to the new one for rollback.
+    /// The new location wins if it already exists.
+    /// </summary>
+    private static async Task MigrateLegacyDatabaseLocation(AppDbContext context, ILogger? logger)
+    {
+        var dbPath = context.Database.GetDbConnection().DataSource;
+        if (string.IsNullOrWhiteSpace(dbPath))
+        {
+            return;
+        }
+
+        var fullDbPath = Path.GetFullPath(dbPath);
+        var dbDirectory = Path.GetDirectoryName(fullDbPath);
+        if (string.IsNullOrWhiteSpace(dbDirectory))
+        {
+            return;
+        }
+
+        var parentDirectory = Directory.GetParent(dbDirectory)?.FullName;
+        if (string.IsNullOrWhiteSpace(parentDirectory))
+        {
+            return;
+        }
+
+        if (!string.Equals(Path.GetFileName(dbDirectory), "config", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        if (File.Exists(fullDbPath))
+        {
+            return;
+        }
+
+        var legacyDbPath = Path.Combine(parentDirectory, "data", Path.GetFileName(fullDbPath));
+        if (!File.Exists(legacyDbPath))
+        {
+            return;
+        }
+
+        Directory.CreateDirectory(dbDirectory);
+        try
+        {
+            await CopySqliteDatabase(legacyDbPath, fullDbPath);
+            await ValidateDatabaseCopy(fullDbPath);
+        }
+        catch
+        {
+            if (File.Exists(fullDbPath))
+            {
+                File.Delete(fullDbPath);
+            }
+
+            throw;
+        }
+
+        logger?.LogInformation("Copied legacy database from {LegacyDbPath} to {DbPath}",
+            legacyDbPath, fullDbPath);
+
+        ArchiveLegacyDatabase(legacyDbPath, GetPreviousDatabasePath(fullDbPath), logger);
+    }
+
+    private static string BuildSqliteConnectionString(string dbPath)
+    {
+        return new SqliteConnectionStringBuilder { DataSource = dbPath }.ToString();
+    }
+
+    private static async Task CopySqliteDatabase(string sourceDbPath, string targetDbPath)
+    {
+        await using var sourceConnection = new SqliteConnection(BuildSqliteConnectionString(sourceDbPath));
+        await using var targetConnection = new SqliteConnection(BuildSqliteConnectionString(targetDbPath));
+        await sourceConnection.OpenAsync();
+        await targetConnection.OpenAsync();
+
+        await using var checkpoint = sourceConnection.CreateCommand();
+        checkpoint.CommandText = SqlitePerformanceInterceptor.FlushWalPragma;
+        await checkpoint.ExecuteNonQueryAsync();
+
+        sourceConnection.BackupDatabase(targetConnection);
+    }
+
+    private static async Task ValidateDatabaseCopy(string dbPath)
+    {
+        await using var connection = new SqliteConnection(BuildSqliteConnectionString(dbPath));
+        await connection.OpenAsync();
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = "PRAGMA quick_check;";
+        var result = await cmd.ExecuteScalarAsync();
+        if (!string.Equals(result?.ToString(), "ok", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException($"Copied database failed SQLite quick_check: {result}");
+        }
+    }
+
+    private static string GetPreviousDatabasePath(string dbPath)
+    {
+        var directory = Path.GetDirectoryName(dbPath) ?? string.Empty;
+        var fileName = Path.GetFileNameWithoutExtension(dbPath);
+        var extension = Path.GetExtension(dbPath);
+        return Path.Combine(directory, $"{fileName}-previous{extension}");
+    }
+
+    private static void ArchiveLegacyDatabase(string legacyDbPath, string previousDbPath, ILogger? logger)
+    {
+        try
+        {
+            File.Move(legacyDbPath, previousDbPath, true);
+            logger?.LogInformation("Moved legacy database from {LegacyDbPath} to {PreviousDbPath}",
+                legacyDbPath, previousDbPath);
+        }
+        catch (Exception ex)
+        {
+            logger?.LogWarning(ex,
+                "Copied legacy database but could not move {LegacyDbPath} to {PreviousDbPath}",
+                legacyDbPath, previousDbPath);
         }
     }
 

--- a/Muxarr.Tests/MigrationTests.cs
+++ b/Muxarr.Tests/MigrationTests.cs
@@ -1,8 +1,10 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
+using Muxarr.Core.Config;
 using Muxarr.Core.Models;
 using Muxarr.Data;
+using Muxarr.Data.Extensions;
 using Muxarr.Data.Entities;
 
 namespace Muxarr.Tests;
@@ -68,6 +70,50 @@ public class MigrationTests : FixtureTestBase
                  '2026-04-01 00:00:00', '2026-04-01 00:00:00',
                  '2026-04-01 00:00:00', '2026-04-01 00:00:00')
             """);
+    }
+
+    [TestMethod]
+    public async Task Initialize_CopiesLegacyDatabaseToConfigAndArchivesOriginal()
+    {
+        var configDbPath = TempPath("config/muxarr.db");
+        var previousDbPath = TempPath("config/muxarr-previous.db");
+        var legacyDbPath = TempPath("data/muxarr.db");
+
+        Directory.CreateDirectory(Path.GetDirectoryName(configDbPath)!);
+        Directory.CreateDirectory(Path.GetDirectoryName(legacyDbPath)!);
+
+        await using (var legacyContext = CreateContext(legacyDbPath))
+        {
+            await legacyContext.Database.MigrateAsync();
+            legacyContext.Configs.Set(new SetupConfig
+            {
+                CompletedAt = new DateTime(2026, 4, 1, 0, 0, 0, DateTimeKind.Utc)
+            });
+            await legacyContext.SaveChangesAsync();
+        }
+
+        await using (var newContext = CreateContext(configDbPath))
+        {
+            await newContext.Initialize();
+        }
+
+        Assert.IsTrue(File.Exists(configDbPath));
+        Assert.IsTrue(File.Exists(previousDbPath));
+        Assert.IsFalse(File.Exists(legacyDbPath));
+
+        await using (var verifyContext = CreateContext(configDbPath))
+        {
+            var setup = await verifyContext.Configs.GetAsync<SetupConfig>();
+            Assert.IsNotNull(setup);
+            Assert.AreEqual(new DateTime(2026, 4, 1, 0, 0, 0, DateTimeKind.Utc), setup.CompletedAt);
+        }
+
+        await using (var previousContext = CreateContext(previousDbPath))
+        {
+            var setup = await previousContext.Configs.GetAsync<SetupConfig>();
+            Assert.IsNotNull(setup);
+            Assert.AreEqual(new DateTime(2026, 4, 1, 0, 0, 0, DateTimeKind.Utc), setup.CompletedAt);
+        }
     }
 
     [TestMethod]

--- a/Muxarr.Web/Components/Pages/Settings/ProcessingSettingsTab.razor
+++ b/Muxarr.Web/Components/Pages/Settings/ProcessingSettingsTab.razor
@@ -120,8 +120,11 @@
             <div class="mb-3">
                 <label class="form-label text-muted">Preview</label>
                 <div class="bg-dark text-light p-2 rounded font-monospace small">
-                    @ProcessingConfig.ResolveCommand("/media/movies/Example Movie (2024)/Example.Movie.2024.1080p.mkv")
+                    @ProcessingConfig.ResolveCommand("/data/movies/Example Movie (2024)/Example.Movie.2024.1080p.mkv")
                 </div>
+                <small class="form-text text-muted">
+                    This preview assumes your media library is mounted at <code>/data</code> inside the container.
+                </small>
             </div>
         }
     </div>

--- a/Muxarr.Web/Components/Pages/Settings/ProfileEdit.razor
+++ b/Muxarr.Web/Components/Pages/Settings/ProfileEdit.razor
@@ -68,7 +68,7 @@
                             <label class="form-label">Monitored Directories</label>
                             <DirectoryEditor @bind-Directories="_profile.Directories"/>
                             <small class="form-text text-muted">Directories to scan for media files using this
-                                profile.</small>
+                                profile. In the container, these should resolve under <code>/data</code>.</small>
                         </div>
                         <div class="mb-3 form-check form-switch">
                             <InputCheckbox id="skipHardlinked" class="form-check-input"

--- a/Muxarr.Web/Components/Pages/Setup.razor
+++ b/Muxarr.Web/Components/Pages/Setup.razor
@@ -102,10 +102,10 @@
         <h4 class="mb-2">You're all set!</h4>
         <p class="text-muted small mb-3">
             Muxarr uses <strong>profiles</strong> to decide how to manage your media files.
-            A profile defines:
+            A profile defines paths under the <code>/data</code> media mount, plus:
         </p>
         <ul class="text-muted small mb-3">
-            <li><strong>Directories</strong> — which folders to scan for media files</li>
+            <li><strong>Directories</strong> — which folders inside <code>/data</code> to scan for media files</li>
             <li><strong>Audio settings</strong> — which audio languages to keep, whether to remove commentary or
                 hearing-impaired tracks
             </li>

--- a/Muxarr.Web/Dockerfile
+++ b/Muxarr.Web/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     mkvtoolnix \
     && rm -rf /var/lib/apt/lists/* \
     && groupadd -g 888 appgroup \
-    && useradd -u 888 -g 888 -d /data -s /bin/false appuser \
+    && useradd -u 888 -g 888 -d /config -s /bin/false appuser \
     && usermod -G users appuser
 
 COPY --from=ffmpeg-dl /out/ffmpeg /usr/local/bin/ffmpeg
@@ -40,7 +40,7 @@ COPY publish/ ./
 COPY entrypoint.sh ./entrypoint.sh
 RUN chmod +x ./entrypoint.sh
 
-VOLUME ["/data"]
+VOLUME ["/config"]
 
 ENV ASPNETCORE_HTTP_PORTS=8183
 EXPOSE 8183

--- a/Muxarr.Web/appsettings.json
+++ b/Muxarr.Web/appsettings.json
@@ -1,5 +1,5 @@
 {
     "ConnectionStrings": {
-        "DefaultConnection": "Data Source=/data/muxarr.db"
+        "DefaultConnection": "Data Source=/config/muxarr.db"
     }
 }

--- a/Muxarr.Web/entrypoint.sh
+++ b/Muxarr.Web/entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 PUID=${PUID:-888}
 PGID=${PGID:-888}
 
-# Temporarily set home to /root to avoid issues with /data not being mounted yet
+# Temporarily set home to /root to avoid issues with /config appdata or /data media mounts not being mounted yet
 USERHOME=$(grep appuser /etc/passwd | cut -d ":" -f6)
 usermod -d /root appuser
 
@@ -15,9 +15,11 @@ usermod -o -u "$PUID" appuser
 # Restore home directory
 usermod -d "$USERHOME" appuser
 
-mkdir -p /data
+mkdir -p /config /data
 chown appuser:appgroup /app || echo "Warning: Could not set ownership on /app. Remote or read-only mount?"
+chown appuser:appgroup /config || echo "Warning: Could not set ownership on /config. Remote or read-only mount?"
 chown appuser:appgroup /data || echo "Warning: Could not set ownership on /data. Remote or read-only mount?"
+chmod 755 /config || true
 chmod 755 /data || true
 
 cd /app

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Muxarr cleans them up by removing unwanted audio and subtitle tracks and standar
 
 ### Quick Start
 
+Inside the container, use `/config` for Muxarr's database and settings, and `/data` for the mounted media library.
+
 ```yaml
 services:
   muxarr:
@@ -31,8 +33,8 @@ services:
       - PUID=1000
       - PGID=1000
     volumes:
-      - /path/to/data:/data
-      - /path/to/media:/media
+      - /path/to/config:/config
+      - /path/to/media:/data
     ports:
       - 8183:8183
     restart: unless-stopped
@@ -93,8 +95,8 @@ docker run -d \
   -e PUID=1000 \
   -e PGID=1000 \
   -p 8183:8183 \
-  -v /path/to/data:/data \
-  -v /path/to/media:/media \
+  -v /path/to/config:/config \
+  -v /path/to/media:/data \
   --restart unless-stopped \
   ghcr.io/kirovair/muxarr:latest
 ```
@@ -113,15 +115,15 @@ docker run -d \
 
 | Path | Description |
 |---|---|
-| `/data` | Database and configuration |
-| `/media` | Media files (use multiple `-v` mounts as needed) |
+| `/config` | Muxarr app data: database, settings, keys, and other persistent state |
+| `/data` | Mounted media library roots used by profiles and processing commands |
 
 ### Setup
 
 1. Open `http://your-ip:8183` - the setup wizard will guide you through
 2. Set a username and password (optional)
 3. Connect Sonarr/Radarr for original language detection and webhook automation (optional)
-4. Create a profile with your media directories and language rules
+4. Create a profile with media directories under the `/data` mount and language rules
 5. Scan your library, preview the changes, and queue files for processing
 
 ### API


### PR DESCRIPTION
## Summary

This changes the Docker/container path contract so Muxarr stores its persistent app data under `/config` and expects mounted media libraries under `/data`.

That matches the common *arr/TRaSH-style convention where:

- `/config` is application state, database, settings, and keys
- `/data` is the shared media/downloads path used by the media stack

## What changed

- Move the default SQLite connection string from `/data/muxarr.db` to `/config/muxarr.db`
- Set the container user's home and declared volume to `/config`
- Ensure the entrypoint prepares both `/config` and `/data`
- Update README, setup, profile, and post-processing examples to describe `/config` and `/data` consistently
- Add startup handling for existing installs that still have `/data/muxarr.db`

## Existing install migration

On startup, if `/config/muxarr.db` does not exist but `/data/muxarr.db` does:

1. Muxarr copies the legacy DB to `/config/muxarr.db` using SQLite's backup API
2. Muxarr validates the copied DB with `PRAGMA quick_check`
3. Muxarr moves the old DB to `/config/muxarr-previous.db` for rollback

If `/config/muxarr.db` already exists, it is left untouched.

## Testing

Tested with:

- `dotnet test Muxarr.Tests/Muxarr.Tests.csproj`
- Result: `507 passed, 1 skipped, 0 failed`
- `dotnet publish Muxarr.Web/Muxarr.Web.csproj -c Release -o Muxarr.Web/publish`
- Docker image build using `Muxarr.Web/Dockerfile`
- Fresh container boot with empty `/config`
- Migration boot using a real existing Muxarr SQLite DB copied from an active homelab install
- Manual conversion testing against media mounted under `/data`

The skipped test is the existing manual ISO language data generator.

Maintainer Note

Note: this was an AI-assisted change, but the scope was intentionally kept narrow: container path behavior, legacy DB migration, docs, and one focused regression test.

The generated code was reviewed manually, adjusted to avoid destructive DB deletion, tested with the project's test suite, and smoke-tested in Docker with both fresh and existing database scenarios.
