### PR TITLE
feat(telegram): add support for topic ids

### DIFF
--- a/Muxarr.Web/Services/Notifications/Providers/TelegramProvider.cs
+++ b/Muxarr.Web/Services/Notifications/Providers/TelegramProvider.cs
@@ -9,6 +9,9 @@ public class TelegramSettings
 
     [Field("Chat ID", HelpText = "User, group, or channel ID to send messages to.")]
     public string ChatId { get; set; } = "";
+
+    [Field("Topic ID", HelpText = "Optional. Thread ID for sending to a specific forum topic.")]
+    public string TopicId { get; set; } = "";
 }
 
 public class TelegramProvider : NotificationProvider<TelegramSettings>
@@ -20,11 +23,20 @@ public class TelegramProvider : NotificationProvider<TelegramSettings>
         // sendMessage caps text at 4096 characters after entity parsing.
         var text = Clip($"<b>{EscapeHtml(payload.Title)}</b>\n{EscapeHtml(payload.Body)}", 4096);
 
-        return PostJsonAsync(client, $"https://api.telegram.org/bot{s.BotToken}/sendMessage", new
+        // message_thread_id must be an integer and only included when set; omit it for
+        // non-forum chats.
+        var body = new Dictionary<string, object?>
         {
-            chat_id = s.ChatId,
-            text,
-            parse_mode = "HTML"
-        });
+            ["chat_id"] = s.ChatId,
+            ["text"] = text,
+            ["parse_mode"] = "HTML"
+        };
+
+        if (long.TryParse(s.TopicId, out var threadId))
+        {
+            body["message_thread_id"] = threadId;
+        }
+
+        return PostJsonAsync(client, $"https://api.telegram.org/bot{s.BotToken}/sendMessage", body);
     }
 }


### PR DESCRIPTION
Allow sending notifications to specific forum topics by adding a TopicId setting and including the message_thread_id in the Telegram API request as documented [here](https://core.telegram.org/bots/api#sendmessage). Tested with my Telegram bot and topic in a group.