### PR TITLE
Add `/conversions` API endpoint

### DIFF
--- a/Muxarr.Core/Api/Models/ConversionResponse.cs
+++ b/Muxarr.Core/Api/Models/ConversionResponse.cs
@@ -1,0 +1,43 @@
+namespace Muxarr.Core.Api.Models;
+
+public class ConversionResponse
+{
+    public int Id { get; init; }
+    public required string Name { get; init; }
+    public required string State { get; init; }
+    public int Progress { get; init; }
+    public long SizeBefore { get; init; }
+    public long SizeAfter { get; init; }
+    public long SizeDifference { get; init; }
+    public string? FilePath { get; init; }
+    public bool IsCustomConversion { get; init; }
+    public DateTime? StartedDate { get; init; }
+    public DateTime CreatedDate { get; init; }
+    public DateTime UpdatedDate { get; init; }
+
+    public static PaginatedResponse<ConversionResponse> Example => new()
+    {
+        Page = 1,
+        PageSize = 25,
+        TotalItems = 1,
+        TotalPages = 1,
+        Items =
+        [
+            new ConversionResponse
+            {
+                Id = 42,
+                Name = "Movie Title",
+                State = "Completed",
+                Progress = 100,
+                SizeBefore = 5368709120,
+                SizeAfter = 3758096384,
+                SizeDifference = 1610612736,
+                FilePath = "/media/movies/movie.mkv",
+                IsCustomConversion = false,
+                StartedDate = new DateTime(2026, 8, 20, 10, 0, 0, DateTimeKind.Utc),
+                CreatedDate = new DateTime(2026, 8, 20, 9, 55, 0, DateTimeKind.Utc),
+                UpdatedDate = new DateTime(2026, 8, 20, 10, 5, 0, DateTimeKind.Utc)
+            }
+        ]
+    };
+}

--- a/Muxarr.Core/Api/Models/PaginatedResponse.cs
+++ b/Muxarr.Core/Api/Models/PaginatedResponse.cs
@@ -1,0 +1,10 @@
+namespace Muxarr.Core.Api.Models;
+
+public class PaginatedResponse<T>
+{
+    public int Page { get; init; }
+    public int PageSize { get; init; }
+    public int TotalItems { get; init; }
+    public int TotalPages { get; init; }
+    public required List<T> Items { get; init; }
+}

--- a/Muxarr.Tests/ConversionsControllerTests.cs
+++ b/Muxarr.Tests/ConversionsControllerTests.cs
@@ -1,0 +1,315 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Muxarr.Core.Api.Models;
+using Muxarr.Data;
+using Muxarr.Data.Entities;
+using Muxarr.Web.Controllers;
+
+namespace Muxarr.Tests;
+
+[TestClass]
+public class ConversionsControllerTests
+{
+    private DbContextOptions<AppDbContext> _dbOptions = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _dbOptions = new DbContextOptionsBuilder<AppDbContext>()
+            .UseSqlite($"Data Source={Path.Combine(Path.GetTempPath(), $"muxarr_conv_test_{Guid.NewGuid():N}.db")}")
+            .Options;
+
+        using var context = new AppDbContext(_dbOptions);
+        context.Database.EnsureCreated();
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        using var context = new AppDbContext(_dbOptions);
+        context.Database.EnsureDeleted();
+    }
+
+    [TestMethod]
+    public async Task ReturnsAllConversionStates()
+    {
+        var states = new[] { ConversionState.New, ConversionState.Processing, ConversionState.Completed, ConversionState.Failed, ConversionState.Cancelled };
+        using (var context = new AppDbContext(_dbOptions))
+        {
+            foreach (var state in states)
+            {
+                context.MediaConversions.Add(new MediaConversion
+                {
+                    Name = $"Test {state}",
+                    State = state,
+                    CreatedDate = DateTime.UtcNow,
+                    UpdatedDate = DateTime.UtcNow
+                });
+            }
+
+            await context.SaveChangesAsync();
+        }
+
+        var result = await GetConversions();
+
+        Assert.AreEqual(5, result.TotalItems);
+        Assert.AreEqual(5, result.Items.Count);
+
+        var returnedStates = result.Items.Select(i => i.State).OrderBy(s => s).ToList();
+        var expectedStates = states.Select(s => s.ToString()).OrderBy(s => s).ToList();
+        CollectionAssert.AreEqual(expectedStates, returnedStates);
+    }
+
+    [TestMethod]
+    public async Task FieldMappingIsCorrect()
+    {
+        var startedDate = new DateTime(2026, 8, 20, 10, 0, 0, DateTimeKind.Utc);
+
+        int conversionId;
+        using (var context = new AppDbContext(_dbOptions))
+        {
+            var profile = CreateProfile(context);
+            var file = new MediaFile { Path = "/media/movies/movie.mkv", Profile = profile };
+            context.MediaFiles.Add(file);
+
+            var conversion = new MediaConversion
+            {
+                Name = "Test Movie",
+                State = ConversionState.Completed,
+                Progress = 100,
+                SizeBefore = 5368709120,
+                SizeAfter = 3758096384,
+                SizeDifference = 1610612736,
+                IsCustomConversion = true,
+                StartedDate = startedDate,
+                MediaFile = file
+            };
+            context.MediaConversions.Add(conversion);
+
+            await context.SaveChangesAsync();
+            conversionId = conversion.Id;
+        }
+
+        // Read back the actual audit dates set by EF
+        DateTime savedCreatedDate, savedUpdatedDate;
+        using (var context = new AppDbContext(_dbOptions))
+        {
+            var saved = await context.MediaConversions.AsNoTracking().SingleAsync(c => c.Id == conversionId);
+            savedCreatedDate = saved.CreatedDate;
+            savedUpdatedDate = saved.UpdatedDate;
+        }
+
+        var result = await GetConversions();
+
+        Assert.AreEqual(1, result.Items.Count);
+        var item = result.Items[0];
+        Assert.AreEqual(conversionId, item.Id);
+        Assert.AreEqual("Test Movie", item.Name);
+        Assert.AreEqual("Completed", item.State);
+        Assert.AreEqual(100, item.Progress);
+        Assert.AreEqual(5368709120, item.SizeBefore);
+        Assert.AreEqual(3758096384, item.SizeAfter);
+        Assert.AreEqual(1610612736, item.SizeDifference);
+        Assert.AreEqual("/media/movies/movie.mkv", item.FilePath);
+        Assert.IsTrue(item.IsCustomConversion);
+        Assert.AreEqual(startedDate, item.StartedDate);
+        Assert.AreEqual(savedCreatedDate, item.CreatedDate);
+        Assert.AreEqual(savedUpdatedDate, item.UpdatedDate);
+    }
+
+    [TestMethod]
+    public async Task DefaultPagination()
+    {
+        using (var context = new AppDbContext(_dbOptions))
+        {
+            for (var i = 0; i < 30; i++)
+            {
+                context.MediaConversions.Add(new MediaConversion
+                {
+                    Name = $"Conversion {i}",
+                    State = ConversionState.Completed,
+                    CreatedDate = DateTime.UtcNow,
+                    UpdatedDate = DateTime.UtcNow
+                });
+            }
+
+            await context.SaveChangesAsync();
+        }
+
+        var result = await GetConversions();
+
+        Assert.AreEqual(1, result.Page);
+        Assert.AreEqual(25, result.PageSize);
+        Assert.AreEqual(30, result.TotalItems);
+        Assert.AreEqual(2, result.TotalPages);
+        Assert.AreEqual(25, result.Items.Count);
+    }
+
+    [TestMethod]
+    public async Task FilePathFilterReturnsMatchingConversions()
+    {
+        using (var context = new AppDbContext(_dbOptions))
+        {
+            var profile = CreateProfile(context);
+            var file1 = new MediaFile { Path = "/media/movies/movie1.mkv", Profile = profile, CreatedDate = DateTime.UtcNow, UpdatedDate = DateTime.UtcNow };
+            var file2 = new MediaFile { Path = "/media/movies/movie2.mkv", Profile = profile, CreatedDate = DateTime.UtcNow, UpdatedDate = DateTime.UtcNow };
+            context.MediaFiles.AddRange(file1, file2);
+
+            context.MediaConversions.Add(new MediaConversion { Name = "Movie 1", State = ConversionState.Completed, MediaFile = file1, CreatedDate = DateTime.UtcNow, UpdatedDate = DateTime.UtcNow });
+            context.MediaConversions.Add(new MediaConversion { Name = "Movie 2", State = ConversionState.Completed, MediaFile = file2, CreatedDate = DateTime.UtcNow, UpdatedDate = DateTime.UtcNow });
+
+            await context.SaveChangesAsync();
+        }
+
+        var result = await GetConversions(filePath: "/media/movies/movie1.mkv");
+
+        Assert.AreEqual(1, result.TotalItems);
+        Assert.AreEqual(1, result.Items.Count);
+        Assert.AreEqual("Movie 1", result.Items[0].Name);
+        Assert.AreEqual("/media/movies/movie1.mkv", result.Items[0].FilePath);
+    }
+
+    [TestMethod]
+    public async Task FilePathFilterReturnsEmptyForNonExistentPath()
+    {
+        using (var context = new AppDbContext(_dbOptions))
+        {
+            var profile = CreateProfile(context);
+            var file = new MediaFile { Path = "/media/movies/movie.mkv", Profile = profile, CreatedDate = DateTime.UtcNow, UpdatedDate = DateTime.UtcNow };
+            context.MediaFiles.Add(file);
+            context.MediaConversions.Add(new MediaConversion { Name = "Movie", State = ConversionState.Completed, MediaFile = file, CreatedDate = DateTime.UtcNow, UpdatedDate = DateTime.UtcNow });
+
+            await context.SaveChangesAsync();
+        }
+
+        var result = await GetConversions(filePath: "/media/movies/nonexistent.mkv");
+
+        Assert.AreEqual(0, result.TotalItems);
+        Assert.AreEqual(0, result.Items.Count);
+        Assert.AreEqual(0, result.TotalPages);
+    }
+
+    [TestMethod]
+    public async Task OrderByCreatedDateDescending()
+    {
+        using (var context = new AppDbContext(_dbOptions))
+        {
+            context.MediaConversions.Add(new MediaConversion { Name = "Oldest", State = ConversionState.Completed });
+            context.MediaConversions.Add(new MediaConversion { Name = "Newest", State = ConversionState.Completed });
+            context.MediaConversions.Add(new MediaConversion { Name = "Middle", State = ConversionState.Completed });
+
+            await context.SaveChangesAsync();
+
+            // Set distinct CreatedDate values via raw SQL (EF overrides them on save)
+            await context.Database.ExecuteSqlRawAsync(
+                "UPDATE MediaConversion SET CreatedDate = '2026-01-01' WHERE Name = 'Oldest'");
+            await context.Database.ExecuteSqlRawAsync(
+                "UPDATE MediaConversion SET CreatedDate = '2026-08-20' WHERE Name = 'Newest'");
+            await context.Database.ExecuteSqlRawAsync(
+                "UPDATE MediaConversion SET CreatedDate = '2026-05-10' WHERE Name = 'Middle'");
+        }
+
+        var result = await GetConversions();
+
+        Assert.AreEqual("Newest", result.Items[0].Name);
+        Assert.AreEqual("Middle", result.Items[1].Name);
+        Assert.AreEqual("Oldest", result.Items[2].Name);
+    }
+
+    [TestMethod]
+    public async Task OrphanedConversionAppearsInUnfilteredResults()
+    {
+        using (var context = new AppDbContext(_dbOptions))
+        {
+            context.MediaConversions.Add(new MediaConversion
+            {
+                Name = "Orphaned",
+                State = ConversionState.Completed,
+                MediaFileId = null,
+                CreatedDate = DateTime.UtcNow,
+                UpdatedDate = DateTime.UtcNow
+            });
+
+            await context.SaveChangesAsync();
+        }
+
+        var result = await GetConversions();
+
+        Assert.AreEqual(1, result.Items.Count);
+        Assert.AreEqual("Orphaned", result.Items[0].Name);
+        Assert.IsNull(result.Items[0].FilePath);
+    }
+
+    [TestMethod]
+    public async Task OrphanedConversionExcludedByFilePathFilter()
+    {
+        using (var context = new AppDbContext(_dbOptions))
+        {
+            context.MediaConversions.Add(new MediaConversion
+            {
+                Name = "Orphaned",
+                State = ConversionState.Completed,
+                MediaFileId = null,
+                CreatedDate = DateTime.UtcNow,
+                UpdatedDate = DateTime.UtcNow
+            });
+
+            await context.SaveChangesAsync();
+        }
+
+        var result = await GetConversions(filePath: "/media/movies/any.mkv");
+
+        Assert.AreEqual(0, result.Items.Count);
+        Assert.AreEqual(0, result.TotalItems);
+    }
+
+    [TestMethod]
+    public async Task PageBeyondTotalPagesReturnsEmpty()
+    {
+        using (var context = new AppDbContext(_dbOptions))
+        {
+            context.MediaConversions.Add(new MediaConversion { Name = "Only", State = ConversionState.Completed, CreatedDate = DateTime.UtcNow, UpdatedDate = DateTime.UtcNow });
+
+            await context.SaveChangesAsync();
+        }
+
+        var result = await GetConversions(page: 5);
+
+        Assert.AreEqual(5, result.Page);
+        Assert.AreEqual(1, result.TotalItems);
+        Assert.AreEqual(1, result.TotalPages);
+        Assert.AreEqual(0, result.Items.Count);
+    }
+
+    private async Task<PaginatedResponse<ConversionResponse>> GetConversions(
+        int page = 1, int pageSize = 25, string? filePath = null)
+    {
+        var factory = new TestDbContextFactory(_dbOptions);
+        var controller = new ConversionsController(factory);
+
+        var actionResult = await controller.Get(page, pageSize, filePath);
+        var okResult = actionResult as OkObjectResult;
+        Assert.IsNotNull(okResult, "Expected OkObjectResult");
+
+        var response = okResult.Value as PaginatedResponse<ConversionResponse>;
+        Assert.IsNotNull(response, "Expected PaginatedResponse<ConversionResponse>");
+
+        return response;
+    }
+
+    private static Profile CreateProfile(AppDbContext context)
+    {
+        var profile = new Profile { Name = "Test", CreatedDate = DateTime.UtcNow, UpdatedDate = DateTime.UtcNow };
+        context.Profiles.Add(profile);
+        context.SaveChanges();
+        return profile;
+    }
+
+    private class TestDbContextFactory(DbContextOptions<AppDbContext> options) : IDbContextFactory<AppDbContext>
+    {
+        public AppDbContext CreateDbContext()
+        {
+            return new AppDbContext(options);
+        }
+    }
+}

--- a/Muxarr.Web/Components/Pages/Settings/ApiSettingsTab.razor
+++ b/Muxarr.Web/Components/Pages/Settings/ApiSettingsTab.razor
@@ -19,6 +19,18 @@
 
     <div class="col-lg-6">
         <div class="card mb-4">
+            <div class="card-header"><i class="bi bi-arrow-repeat me-2"></i>GET /api/conversions</div>
+            <div class="card-body">
+                <p class="text-muted small mb-2">Request</p>
+                <CodeBlock Value="@ConversionsCurlExample"/>
+                <p class="text-muted small mb-2 mt-3">Response</p>
+                <CodeBlock Value="@ConversionsResponseExample"/>
+            </div>
+        </div>
+    </div>
+
+    <div class="col-lg-6">
+        <div class="card mb-4">
             <div class="card-header"><i class="bi bi-layout-text-sidebar me-2"></i>Homepage Widget</div>
             <div class="card-body">
                 <p class="text-muted small mb-2">
@@ -48,9 +60,13 @@
     }
 
     private string StatsUrl => $"{_baseUrl}/api/stats";
+    private string ConversionsUrl => $"{_baseUrl}/api/conversions";
 
     private string CurlExample =>
         $"curl -H \"X-Api-Key: {_apiKey}\" {StatsUrl}";
+
+    private string ConversionsCurlExample =>
+        $"curl -H \"X-Api-Key: {_apiKey}\" \"{ConversionsUrl}?filePath=%2Fmedia%2Fmovies%2Fmovie.mkv\"";
 
     private static readonly Lazy<string> ExampleJson = new(() =>
     {
@@ -60,7 +76,16 @@
         return JsonSerializer.Serialize(StatsResponse.Example, options);
     });
 
+    private static readonly Lazy<string> ConversionsExampleJson = new(() =>
+    {
+        var options = JsonHelper.JsonDotNetDefaults;
+        options.WriteIndented = true;
+        options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+        return JsonSerializer.Serialize(ConversionResponse.Example, options);
+    });
+
     private string ResponseExample => ExampleJson.Value;
+    private string ConversionsResponseExample => ConversionsExampleJson.Value;
 
     private string HomepageExample =>
         $@"- Muxarr:

--- a/Muxarr.Web/Controllers/ConversionsController.cs
+++ b/Muxarr.Web/Controllers/ConversionsController.cs
@@ -1,0 +1,57 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Muxarr.Core.Api.Models;
+using Muxarr.Data;
+using Muxarr.Data.Extensions;
+using Muxarr.Web.Authentication;
+
+namespace Muxarr.Web.Controllers;
+
+[Authorize(AuthenticationSchemes = AuthSchemes.ApiKey)]
+public class ConversionsController(IDbContextFactory<AppDbContext> contextFactory) : Controller
+{
+    [HttpGet]
+    [Route("~/api/conversions")]
+    public async Task<IActionResult> Get(int page = 1, int pageSize = 25, string? filePath = null)
+    {
+        await using var context = await contextFactory.CreateDbContextAsync();
+
+        var query = context.MediaConversions
+            .Include(c => c.MediaFile)
+            .AsQueryable();
+
+        if (filePath != null)
+        {
+            query = query.Where(c => c.MediaFile != null && c.MediaFile.Path == filePath);
+        }
+
+        query = query.OrderByDescending(c => c.CreatedDate);
+
+        var (data, total, totalPages) = await query.FindPagedAsync(page, pageSize, noTracking: true);
+        var items = await data.ToListAsync();
+
+        return Ok(new PaginatedResponse<ConversionResponse>
+        {
+            Page = page,
+            PageSize = pageSize,
+            TotalItems = total,
+            TotalPages = totalPages,
+            Items = items.Select(c => new ConversionResponse
+            {
+                Id = c.Id,
+                Name = c.Name,
+                State = c.State.ToString(),
+                Progress = c.Progress,
+                SizeBefore = c.SizeBefore,
+                SizeAfter = c.SizeAfter,
+                SizeDifference = c.SizeDifference,
+                FilePath = c.MediaFile?.Path,
+                IsCustomConversion = c.IsCustomConversion,
+                StartedDate = c.StartedDate,
+                CreatedDate = c.CreatedDate,
+                UpdatedDate = c.UpdatedDate
+            }).ToList()
+        });
+    }
+}

--- a/README.md
+++ b/README.md
@@ -155,7 +155,12 @@ Until you do, Muxarr keeps running from `/data` and shows a reminder in the app.
 
 ### API
 
-Muxarr exposes a stats API at `/api/stats` (authenticated via `X-Api-Key` header). Works with [Homepage](https://gethomepage.dev/widgets/services/customapi/) and other dashboards. See Settings > API for examples.
+Muxarr exposes a REST API authenticated via the `X-Api-Key` header. See Settings > API for examples.
+
+| Endpoint | Description |
+|---|---|
+| `GET /api/stats` | Library statistics — works with [Homepage](https://gethomepage.dev/widgets/services/customapi/) and other dashboards |
+| `GET /api/conversions` | Paginated list of all conversions. Supports `page`, `pageSize`, and an optional `filePath` query parameter to filter by media file path (URL-encoded) |
 
 ## Built With
 


### PR DESCRIPTION
This PR adds an `/api/conversions` endpoint to query all conversions.

The primary use case of this feature is for other automation to trigger a conversion and then poll until the conversion has finished.

The endpoint has pagination implemented to prevent OOM killing, and is implicitly ordered by creation date descending.

I have only added support for the `filePath` query string parameter as this is needed for my use-case, however, it is quite easy to add other query string filters in the future.

Unit tests have been added and I have manually tested a Docker build locally with everything working correctly.

I have updated the README docs and added an example to the Web UI's API tab.

### Web UI Docs
<img width="5088" height="3388" alt="Muxarr - Settings" src="https://github.com/user-attachments/assets/6ede9e06-323a-484f-98aa-323d4da90244" />

### Manual Test (all)

```bash
curl \
  -H "X-Api-Key: 55dc16202c5645ea8847e1a9098a12fc" \
  "http://localhost:8183/api/conversions?pageSize=6" \
  | jq .
```

```json
{
  "page": 1,
  "pageSize": 6,
  "totalItems": 6,
  "totalPages": 1,
  "items": [
    {
      "id": 6,
      "name": "A Knight of the Seven Kingdoms - S01E05 - In the Name of the Mother [Bluray-2160p Remux]",
      "state": "New",
      "progress": 0,
      "sizeBefore": 23120876702,
      "sizeAfter": 0,
      "sizeDifference": 0,
      "filePath": "/media/A Knight of the Seven Kingdoms/A Knight of the Seven Kingdoms - S01E05 - In the Name of the Mother [Bluray-2160p Remux].mkv",
      "isCustomConversion": false,
      "startedDate": null,
      "createdDate": "2026-08-20T14:12:00.7585384",
      "updatedDate": "2026-08-20T14:12:00.7585384"
    },
    {
      "id": 5,
      "name": "A Knight of the Seven Kingdoms - S01E01 - The Hedge Knight [Bluray-2160p Remux]",
      "state": "New",
      "progress": 0,
      "sizeBefore": 27067477478,
      "sizeAfter": 0,
      "sizeDifference": 0,
      "filePath": "/media/A Knight of the Seven Kingdoms/A Knight of the Seven Kingdoms - S01E01 - The Hedge Knight [Bluray-2160p Remux].mkv",
      "isCustomConversion": false,
      "startedDate": null,
      "createdDate": "2026-08-20T14:12:00.7542136",
      "updatedDate": "2026-08-20T14:12:00.7542136"
    },
    {
      "id": 4,
      "name": "A Knight of the Seven Kingdoms - S01E02 - Hard Salt Beef [Bluray-2160p Remux]",
      "state": "New",
      "progress": 0,
      "sizeBefore": 21122446790,
      "sizeAfter": 0,
      "sizeDifference": 0,
      "filePath": "/media/A Knight of the Seven Kingdoms/A Knight of the Seven Kingdoms - S01E02 - Hard Salt Beef [Bluray-2160p Remux].mkv",
      "isCustomConversion": false,
      "startedDate": null,
      "createdDate": "2026-08-20T14:12:00.751032",
      "updatedDate": "2026-08-20T14:12:00.751032"
    },
    {
      "id": 3,
      "name": "A Knight of the Seven Kingdoms - S01E03 - The Squire [Bluray-2160p Remux]",
      "state": "New",
      "progress": 0,
      "sizeBefore": 19538344797,
      "sizeAfter": 0,
      "sizeDifference": 0,
      "filePath": "/media/A Knight of the Seven Kingdoms/A Knight of the Seven Kingdoms - S01E03 - The Squire [Bluray-2160p Remux].mkv",
      "isCustomConversion": false,
      "startedDate": null,
      "createdDate": "2026-08-20T14:12:00.7471306",
      "updatedDate": "2026-08-20T14:12:00.7471306"
    },
    {
      "id": 2,
      "name": "A Knight of the Seven Kingdoms - S01E04 - Seven [Bluray-2160p Remux]",
      "state": "New",
      "progress": 0,
      "sizeBefore": 21965895078,
      "sizeAfter": 0,
      "sizeDifference": 0,
      "filePath": "/media/A Knight of the Seven Kingdoms/A Knight of the Seven Kingdoms - S01E04 - Seven [Bluray-2160p Remux].mkv",
      "isCustomConversion": false,
      "startedDate": null,
      "createdDate": "2026-08-20T14:12:00.7434346",
      "updatedDate": "2026-08-20T14:12:00.7434346"
    },
    {
      "id": 1,
      "name": "A Knight of the Seven Kingdoms - S01E06 - The Morrow [Bluray-2160p Remux]",
      "state": "Processing",
      "progress": 0,
      "sizeBefore": 19368602545,
      "sizeAfter": 0,
      "sizeDifference": 0,
      "filePath": "/media/A Knight of the Seven Kingdoms/A Knight of the Seven Kingdoms - S01E06 - The Morrow [Bluray-2160p Remux].mkv",
      "isCustomConversion": false,
      "startedDate": "2026-08-20T14:12:00.8769895",
      "createdDate": "2026-08-20T14:12:00.7175876",
      "updatedDate": "2026-08-20T14:12:00.8853543"
    }
  ]
}
```

### Manual Test (filtered by `filePath`)

```bash
curl \
  -H "X-Api-Key: 55dc16202c5645ea8847e1a9098a12fc" \
  "http://localhost:8183/api/conversions?pageSize=6&filePath=%2Fmedia%2FA%20Knight%20of%20the%20Seven%20Kingdoms%2FA%20Knight%20of%20the%20Seven%20Kingdoms%20-%20S01E06%20-%20The%20Morrow%20%5BBluray-2160p%20Remux%5D.mkv" \
  | jq .
```

```json
{
  "page": 1,
  "pageSize": 6,
  "totalItems": 1,
  "totalPages": 1,
  "items": [
    {
      "id": 1,
      "name": "A Knight of the Seven Kingdoms - S01E06 - The Morrow [Bluray-2160p Remux]",
      "state": "Processing",
      "progress": 0,
      "sizeBefore": 19368602545,
      "sizeAfter": 0,
      "sizeDifference": 0,
      "filePath": "/media/A Knight of the Seven Kingdoms/A Knight of the Seven Kingdoms - S01E06 - The Morrow [Bluray-2160p Remux].mkv",
      "isCustomConversion": false,
      "startedDate": "2026-08-20T14:12:00.8769895",
      "createdDate": "2026-08-20T14:12:00.7175876",
      "updatedDate": "2026-08-20T14:12:00.8853543"
    }
  ]
}
```